### PR TITLE
When a property value or item include is null, do not add the item.

### DIFF
--- a/src/MSBuildProjectCreator.UnitTests/ItemTests.cs
+++ b/src/MSBuildProjectCreator.UnitTests/ItemTests.cs
@@ -116,6 +116,22 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
         }
 
         [Fact]
+        public void ItemIncludeNotAddedIfNull()
+        {
+            ProjectCreator.Create(projectFileOptions: NewProjectFileOptions.None)
+                .ItemInclude("D7DAD38333D04A5999F9791575DBB57D", null)
+                .ItemInclude("FDA04096ED074663997F13D37E81E87A", "CBCFA7D42A3B4A1B93127FAFA13CD3DB")
+                .Xml
+                .ShouldBe(
+                    @"<Project>
+  <ItemGroup>
+    <FDA04096ED074663997F13D37E81E87A Include=""CBCFA7D42A3B4A1B93127FAFA13CD3DB"" />
+  </ItemGroup>
+</Project>",
+                    StringCompareShould.IgnoreLineEndings);
+        }
+
+        [Fact]
         public void NoneItem()
         {
             ProjectCreator.Create(projectFileOptions: NewProjectFileOptions.None)

--- a/src/MSBuildProjectCreator.UnitTests/PropertyTests.cs
+++ b/src/MSBuildProjectCreator.UnitTests/PropertyTests.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Build.Evaluation;
 using Shouldly;
+using System;
 using Xunit;
 
 namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
@@ -42,6 +43,37 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
                     @"<Project>
   <PropertyGroup>
     <E1A695D73E91481A9D1FAEE1C4C8407C Condition="" '$(E1A695D73E91481A9D1FAEE1C4C8407C)' == '' And 9894AD0320B64027AA92732D436A5F0A "">5C50C035A20E4372B6A64C08D111F9F7</E1A695D73E91481A9D1FAEE1C4C8407C>
+  </PropertyGroup>
+</Project>",
+                    StringCompareShould.IgnoreLineEndings);
+        }
+
+        [Fact]
+        public void PropertyNotSetIfNull()
+        {
+            ProjectCreator.Create(projectFileOptions: NewProjectFileOptions.None)
+                .Property("BFB895A7AD3F4CAFBE514DCFE5D30354", null)
+                .Property("B712A0D4A328439E8862D6715E044AB7", "2C9E4222FEBF43F7B841099EC3DDB14B")
+                .Xml
+                .ShouldBe(
+                    @"<Project>
+  <PropertyGroup>
+    <B712A0D4A328439E8862D6715E044AB7>2C9E4222FEBF43F7B841099EC3DDB14B</B712A0D4A328439E8862D6715E044AB7>
+  </PropertyGroup>
+</Project>",
+                    StringCompareShould.IgnoreLineEndings);
+        }
+
+        [Fact]
+        public void PropertySetIfEmpty()
+        {
+            ProjectCreator.Create(projectFileOptions: NewProjectFileOptions.None)
+                .Property("A47F78111F084710B139CD5AEEB5395E", String.Empty)
+                .Xml
+                .ShouldBe(
+                    @"<Project>
+  <PropertyGroup>
+    <A47F78111F084710B139CD5AEEB5395E />
   </PropertyGroup>
 </Project>",
                     StringCompareShould.IgnoreLineEndings);

--- a/src/MSBuildProjectCreator/ProjectCreator.Items.cs
+++ b/src/MSBuildProjectCreator/ProjectCreator.Items.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         }
 
         /// <summary>
-        /// Adds an item to the current item group.
+        /// Adds an item to the current item group.  If <paramref name="include"/> is null, the item is not added.
         /// </summary>
         /// <param name="itemType">The type of the item to add.</param>
         /// <param name="include">The file or wildcard to include in the list of items.</param>
@@ -91,7 +91,10 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             IDictionary<string, string> metadata = null,
             string condition = null)
         {
-            return Item(LastItemGroup, itemType, include, exclude, metadata, null, null, condition);
+            return
+                include == null
+                    ? this
+                    : Item(LastItemGroup, itemType, include, exclude, metadata, null, null, condition);
         }
 
         /// <summary>

--- a/src/MSBuildProjectCreator/ProjectCreator.Properties.cs
+++ b/src/MSBuildProjectCreator/ProjectCreator.Properties.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         }
 
         /// <summary>
-        /// Adds a property element to the current &lt;PropertyGroup /&gt;.  A property group is automatically added if necessary.
+        /// Adds a property element to the current &lt;PropertyGroup /&gt;.  A property group is automatically added if necessary.  if <paramref name="unevaluatedValue"/> is <code>null</code>, the property is not added.
         /// </summary>
         /// <param name="propertyGroup">The <see cref="ProjectPropertyGroupElement"/> to add the property to.</param>
         /// <param name="name">The name of the property.</param>
@@ -38,6 +38,11 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// </remarks>
         private ProjectCreator Property(ProjectPropertyGroupElement propertyGroup, string name, string unevaluatedValue, string condition = null, bool setIfEmpty = false)
         {
+            if (unevaluatedValue == null)
+            {
+                return this;
+            }
+
             ProjectPropertyElement propertyElement = propertyGroup.AddProperty(name, unevaluatedValue);
 
             if (setIfEmpty && condition != null)

--- a/src/MSBuildProjectCreator/Templates/SdkCsproj.cs
+++ b/src/MSBuildProjectCreator/Templates/SdkCsproj.cs
@@ -37,28 +37,17 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             ProjectCollection projectCollection = null,
             NewProjectFileOptions? projectFileOptions = NewProjectFileOptions.None)
         {
-            ProjectCreator creator = ProjectCreator.Create(
-                path,
-                sdk: sdk,
-                defaultTargets: defaultTargets,
-                initialTargets: initialTargets,
-                treatAsLocalProperty: treatAsLocalProperty,
-                projectCollection: projectCollection,
-                projectFileOptions: projectFileOptions);
-
-            if (targetFramework != null)
-            {
-                creator.Property("TargetFramework", targetFramework);
-            }
-
-            if (outputType != null)
-            {
-                creator.Property("OutputType", outputType);
-            }
-
-            projectCreator?.Invoke(creator);
-
-            return creator;
+            return ProjectCreator.Create(
+                    path,
+                    sdk: sdk,
+                    defaultTargets: defaultTargets,
+                    initialTargets: initialTargets,
+                    treatAsLocalProperty: treatAsLocalProperty,
+                    projectCollection: projectCollection,
+                    projectFileOptions: projectFileOptions)
+                .Property("TargetFramework", targetFramework)
+                .Property("OutputType", outputType)
+                .CustomAction(projectCreator);
         }
 
         /// <summary>
@@ -87,25 +76,18 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             ProjectCollection projectCollection = null,
             NewProjectFileOptions? projectFileOptions = NewProjectFileOptions.None)
         {
-            ProjectCreator creator = SdkCsproj(
-                path: path,
-                sdk: sdk,
-                targetFramework: null,
-                outputType: outputType,
-                defaultTargets: defaultTargets,
-                initialTargets: initialTargets,
-                treatAsLocalProperty: treatAsLocalProperty,
-                projectCollection: projectCollection,
-                projectFileOptions: projectFileOptions);
-
-            if (targetFrameworks != null)
-            {
-                creator.Property("TargetFrameworks", String.Join(";", targetFrameworks));
-            }
-
-            projectCreator?.Invoke(creator);
-
-            return creator;
+            return SdkCsproj(
+                    path: path,
+                    sdk: sdk,
+                    targetFramework: null,
+                    outputType: outputType,
+                    defaultTargets: defaultTargets,
+                    initialTargets: initialTargets,
+                    treatAsLocalProperty: treatAsLocalProperty,
+                    projectCollection: projectCollection,
+                    projectFileOptions: projectFileOptions)
+                .Property("TargetFrameworks", targetFrameworks == null ? null : String.Join(";", targetFrameworks))
+                .CustomAction(projectCreator);
         }
     }
 }


### PR DESCRIPTION
This makes the API more fluent when adding properties coming from optional method parameters (like templates)