### PR TITLE
Fix issue with version of Visual Studio.

### DIFF
--- a/src/MSBuildProjectCreator/MSBuildAssemblyResolver.cs
+++ b/src/MSBuildProjectCreator/MSBuildAssemblyResolver.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
 
                 if (highestVersion != null)
                 {
-                    return Path.Combine(highestVersion.Item2, "MSBuild", GetMSBuildVersionDirectory($"{highestVersion.Item1.Major}.{highestVersion.Item1.Minor}"), "Bin");
+                    return Path.Combine(highestVersion.Item2, "MSBuild", GetMSBuildVersionDirectory($"{highestVersion.Item1.Major}.0"), "Bin");
                 }
             }
             catch


### PR DESCRIPTION
Only need major.0 to translate the name of the folder for MSBuild.