### PR TITLE
Fix package repository logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,23 +167,27 @@ NuGet and MSBuild are very tightly coupled and a lot of times you need packages 
 Create a package repository with a package that supports two target frameworks:
 
 ```C#
-PackageRepository.Create(rootPath)
-    .Package("MyPackage", "1.2.3", out PackageIdentify package)
+using(PackageRepository.Create(rootPath)
+    .Package("MyPackage", "1.2.3", out PackageIdentity package)
         .Library("net472")
-        .Library("netstandard2.0");
+        .Library("netstandard2.0"))
+{
+    // Create projects that reference packages
+}
 ```
 
 The resulting package would have a `lib\net472\MyPackage.dll` and `lib\netstandard2.0\MyPackage.dll` class library.  This allows you to restore and build projects that consume the packages
 
 ```C#
-PackageRepository.Create(rootPath)
-    .Package("MyPackage", "1.0.0", out PackageIdentify package)
-        .Library("netstandard2.0");
-
-ProjectCreator.Templates.SdkCsproj()
-    .ItemPackageReference(package)
-    .Save(Path.Combine(rootPath, "ClassLibraryA", "ClassLibraryA.csproj"))
-    .TryBuild(restore: true, out bool result, out BuildOutput buildOutput);
+using(PackageRepository.Create(rootPath)
+    .Package("MyPackage", "1.0.0", out PackageIdentity package)
+        .Library("netstandard2.0"))
+{
+    ProjectCreator.Templates.SdkCsproj()
+        .ItemPackageReference(package)
+        .Save(Path.Combine(rootPath, "ClassLibraryA", "ClassLibraryA.csproj"))
+        .TryBuild(restore: true, out bool result, out BuildOutput buildOutput);
+}
 ```
 
 The result would be a project that references the `MyPackage` package and would restore and build accordingly.

--- a/src/MSBuildProjectCreator.UnitTests/BuildTests.cs
+++ b/src/MSBuildProjectCreator.UnitTests/BuildTests.cs
@@ -6,9 +6,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
-using NuGet.Packaging.Core;
 using Shouldly;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -18,25 +16,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
 {
     public class BuildTests : TestBase
     {
-        [Fact]
-        public void BuildCanConsumePackage()
-        {
-            PackageRepository packageRepository = PackageRepository.Create(TestRootPath)
-                .Package("PackageB", "1.0", out PackageIdentity packageB)
-                .Library("net45")
-                .Package("PackageA", "1.0.0", out PackageIdentity packageA)
-                .Dependency(packageB, "net45")
-                .Library("net45");
-
-            ProjectCreator.Templates.SdkCsproj(
-                    targetFramework: "net45")
-                .ItemPackageReference(packageA)
-                .Save(Path.Combine(TestRootPath, "ClassLibraryA", "ClassLibraryA.csproj"))
-                .TryBuild(restore: true, out bool result, out BuildOutput buildOutput);
-
-            result.ShouldBeTrue(buildOutput.GetConsoleLog());
-        }
-
         [Fact]
         public void BuildTargetOutputsTest()
         {

--- a/src/MSBuildProjectCreator.UnitTests/PackageRepositoryTests/DependencyTests.cs
+++ b/src/MSBuildProjectCreator.UnitTests/PackageRepositoryTests/DependencyTests.cs
@@ -19,64 +19,68 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageRepositoryT
         [Fact]
         public void CanAddDependenciesToMultipleGroups()
         {
-            PackageRepository.Create(TestRootPath)
+            using (PackageRepository packageRepository = PackageRepository.Create(TestRootPath)
                 .Package("PackageA", "1.0.0", out PackageIdentity package)
-                    .Dependency("PackageB", "1.0.0", "net45")
-                    .Dependency("PackageB", "1.0.0", "net46")
-                    .Dependency("PackageB", "1.0.0", "netstandard2.0");
-
-            ValidatePackageDependencies(
-                package,
-                new List<PackageDependencyGroup>
-                {
-                    new PackageDependencyGroup(
-                        FrameworkConstants.CommonFrameworks.Net45,
-                        new List<PackageDependency>
-                        {
-                            new PackageDependency("PackageB", VersionRange.Parse("1.0.0")),
-                        }),
-                    new PackageDependencyGroup(
-                        FrameworkConstants.CommonFrameworks.Net46,
-                        new List<PackageDependency>
-                        {
-                            new PackageDependency("PackageB", VersionRange.Parse("1.0.0")),
-                        }),
-                    new PackageDependencyGroup(
-                        FrameworkConstants.CommonFrameworks.NetStandard20,
-                        new List<PackageDependency>
-                        {
-                            new PackageDependency("PackageB", VersionRange.Parse("1.0.0")),
-                        }),
-                });
+                .Dependency("PackageB", "1.0.0", "net45")
+                .Dependency("PackageB", "1.0.0", "net46")
+                .Dependency("PackageB", "1.0.0", "netstandard2.0"))
+            {
+                ValidatePackageDependencies(
+                    packageRepository,
+                    package,
+                    new List<PackageDependencyGroup>
+                    {
+                        new PackageDependencyGroup(
+                            FrameworkConstants.CommonFrameworks.Net45,
+                            new List<PackageDependency>
+                            {
+                                new PackageDependency("PackageB", VersionRange.Parse("1.0.0")),
+                            }),
+                        new PackageDependencyGroup(
+                            FrameworkConstants.CommonFrameworks.Net46,
+                            new List<PackageDependency>
+                            {
+                                new PackageDependency("PackageB", VersionRange.Parse("1.0.0")),
+                            }),
+                        new PackageDependencyGroup(
+                            FrameworkConstants.CommonFrameworks.NetStandard20,
+                            new List<PackageDependency>
+                            {
+                                new PackageDependency("PackageB", VersionRange.Parse("1.0.0")),
+                            }),
+                    });
+            }
         }
 
         [Fact]
         public void CanAddMultipleDependenciesToSameGroup()
         {
-            PackageRepository.Create(TestRootPath)
+            using (PackageRepository packageRepository = PackageRepository.Create(TestRootPath)
                 .Package("PackageA", "1.0.0", out PackageIdentity package)
-                    .Dependency("PackageB", "1.0.0", "net45")
-                    .Dependency("PackageC", "1.1.0", "net45")
-                    .Dependency("PackageD", "1.2.0", "net45");
-
-            ValidatePackageDependencies(
-                package,
-                new List<PackageDependencyGroup>
-                {
-                    new PackageDependencyGroup(
-                        FrameworkConstants.CommonFrameworks.Net45,
-                        new List<PackageDependency>
-                        {
-                            new PackageDependency("PackageB", VersionRange.Parse("1.0.0")),
-                            new PackageDependency("PackageC", VersionRange.Parse("1.1.0")),
-                            new PackageDependency("PackageD", VersionRange.Parse("1.2.0")),
-                        }),
-                });
+                .Dependency("PackageB", "1.0.0", "net45")
+                .Dependency("PackageC", "1.1.0", "net45")
+                .Dependency("PackageD", "1.2.0", "net45"))
+            {
+                ValidatePackageDependencies(
+                    packageRepository,
+                    package,
+                    new List<PackageDependencyGroup>
+                    {
+                        new PackageDependencyGroup(
+                            FrameworkConstants.CommonFrameworks.Net45,
+                            new List<PackageDependency>
+                            {
+                                new PackageDependency("PackageB", VersionRange.Parse("1.0.0")),
+                                new PackageDependency("PackageC", VersionRange.Parse("1.1.0")),
+                                new PackageDependency("PackageD", VersionRange.Parse("1.2.0")),
+                            }),
+                    });
+            }
         }
 
-        private void ValidatePackageDependencies(PackageIdentity package, IEnumerable<PackageDependencyGroup> expectedDependencyGroups)
+        private void ValidatePackageDependencies(PackageRepository packageRepository, PackageIdentity package, IEnumerable<PackageDependencyGroup> expectedDependencyGroups)
         {
-            FileInfo nuspecFile = new FileInfo(((VersionFolderPathResolver)VersionFolderPathResolver).GetManifestFilePath(package.Id, package.Version));
+            FileInfo nuspecFile = new FileInfo(packageRepository.GetManifestFilePath(package.Id, package.Version));
 
             nuspecFile.ShouldExist();
 

--- a/src/MSBuildProjectCreator.UnitTests/SdkCsprojTests.cs
+++ b/src/MSBuildProjectCreator.UnitTests/SdkCsprojTests.cs
@@ -26,32 +26,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
         }
 
         [Fact]
-        public void CanUseNuGetSdkResolver()
-        {
-            using (ProjectCollection projectCollection = new ProjectCollection())
-            {
-                BuildOutput buildOutput = BuildOutput.Create();
-
-                projectCollection.RegisterLogger(buildOutput);
-
-                ProjectCreator projectCreator = ProjectCreator
-                    .Create(projectCollection: projectCollection)
-                    .ImportSdk("Sdk.props", "Microsoft.Build.NoTargets", "1.0.53")
-                    .ImportSdk("Sdk.targets", "Microsoft.Build.NoTargets", "1.0.53")
-                    .Save(GetTempFileName(".csproj"));
-
-                try
-                {
-                    Project unused = projectCreator.Project;
-                }
-                catch (Exception e)
-                {
-                    throw new Exception(buildOutput.GetConsoleLog(), e);
-                }
-            }
-        }
-
-        [Fact]
         public void CustomSdk()
         {
             const string sdk = "Foo/1.2.3";

--- a/src/MSBuildProjectCreator/MSBuildTestBase.cs
+++ b/src/MSBuildProjectCreator/MSBuildTestBase.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Collections.Generic;
 
 namespace Microsoft.Build.Utilities.ProjectCreation
 {

--- a/src/MSBuildProjectCreator/PackageManifest.cs
+++ b/src/MSBuildProjectCreator/PackageManifest.cs
@@ -19,35 +19,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation
     /// </summary>
     internal class PackageManifest : Manifest
     {
-#if NET46
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PackageManifest"/> class.
-        /// </summary>
-        /// <param name="fullPath">The full path to the manifest file.</param>
-        /// <param name="name">The name or ID of the package.</param>
-        /// <param name="version">The semantic version of the package.</param>
-        /// <param name="authors">An optional semicolon delimited list of authors of the package.  The default value is &quot;UserA&quot;</param>
-        /// <param name="description">An optional description of the package.  The default value is &quot;Description&quot;</param>
-        /// <param name="copyright">An optional copyright of the package.</param>
-        /// <param name="developmentDependency">An optional value indicating whether or not the package is a development dependency.  The default value is <code>false</code>.</param>
-        /// <param name="iconUrl">An optional URL to the icon of the package.</param>
-        /// <param name="language">An optional language of the package.</param>
-        /// <param name="licenseUrl">An optional URL to the license of the package.</param>
-        /// <param name="licenseMetadata">An optional <see cref="LicenseMetadata" /> of the package.</param>
-        /// <param name="owners">An optional semicolon delimited list of owners of the package.</param>
-        /// <param name="packageTypes">An optional <see cref="IEnumerable{PackageType}" /> containing the package types of the package.</param>
-        /// <param name="projectUrl">An optional URL to the project of the package.</param>
-        /// <param name="releaseNotes">An optional value specifying release notes of the package.</param>
-        /// <param name="repositoryType">An optional value specifying the type of source code repository of the package.</param>
-        /// <param name="repositoryUrl">An optional value specifying the URL of the source code repository of the package.</param>
-        /// <param name="repositoryBranch">An optional value specifying the branch of the source code repository of the package.</param>
-        /// <param name="repositoryCommit">An optional value specifying the commit of the source code repository of the package.</param>
-        /// <param name="requireLicenseAcceptance">An optional value indicating whether or not the package requires license acceptance  The default value is <code>false</code>.</param>
-        /// <param name="serviceable">An option value indicating whether or not the package is serviceable.  The default value is <code>false</code>.</param>
-        /// <param name="summary">An optional summary of the package.</param>
-        /// <param name="tags">An optional set of tags of the package.</param>
-        /// <param name="title">An optional title of the package.</param>
-#else
         /// <summary>
         /// Initializes a new instance of the <see cref="PackageManifest"/> class.
         /// </summary>
@@ -76,8 +47,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="summary">An optional summary of the package.</param>
         /// <param name="tags">An optional set of tags of the package.</param>
         /// <param name="title">An optional title of the package.</param>
-#endif
-
         public PackageManifest(
             string fullPath,
             string name,
@@ -86,9 +55,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             string description = null,
             string copyright = null,
             bool developmentDependency = false,
-#if !NET46
             string icon = null,
-#endif
             string iconUrl = null,
             string language = null,
             string licenseUrl = null,
@@ -114,9 +81,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
                     description,
                     copyright,
                     developmentDependency,
-#if !NET46
                     icon,
-#endif
                     iconUrl,
                     language,
                     licenseUrl,
@@ -202,38 +167,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             }
         }
 
-#if NET46
-        /// <summary>
-        /// Gets the <see cref="ManifestMetadata" /> for a package.
-        /// </summary>
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PackageManifest"/> class.
-        /// </summary>
-        /// <param name="name">The name or ID of the package.</param>
-        /// <param name="version">The semantic version of the package.</param>
-        /// <param name="authors">An optional semicolon delimited list of authors of the package.  The default value is &quot;UserA&quot;</param>
-        /// <param name="description">An optional description of the package.  The default value is &quot;Description&quot;</param>
-        /// <param name="copyright">An optional copyright of the package.</param>
-        /// <param name="developmentDependency">An optional value indicating whether or not the package is a development dependency.  The default value is <code>false</code>.</param>
-        /// <param name="iconUrl">An optional URL to the icon of the package.</param>
-        /// <param name="language">An optional language of the package.</param>
-        /// <param name="licenseUrl">An optional URL to the license of the package.</param>
-        /// <param name="licenseMetadata">An optional <see cref="LicenseMetadata" /> of the package.</param>
-        /// <param name="owners">An optional semicolon delimited list of owners of the package.</param>
-        /// <param name="packageTypes">An optional <see cref="IEnumerable{PackageType}" /> containing the package types of the package.</param>
-        /// <param name="projectUrl">An optional URL to the project of the package.</param>
-        /// <param name="releaseNotes">An optional value specifying release notes of the package.</param>
-        /// <param name="repositoryType">An optional value specifying the type of source code repository of the package.</param>
-        /// <param name="repositoryUrl">An optional value specifying the URL of the source code repository of the package.</param>
-        /// <param name="repositoryBranch">An optional value specifying the branch of the source code repository of the package.</param>
-        /// <param name="repositoryCommit">An optional value specifying the commit of the source code repository of the package.</param>
-        /// <param name="requireLicenseAcceptance">An optional value indicating whether or not the package requires license acceptance  The default value is <code>false</code>.</param>
-        /// <param name="serviceable">An option value indicating whether or not the package is serviceable.  The default value is <code>false</code>.</param>
-        /// <param name="summary">An optional summary of the package.</param>
-        /// <param name="tags">An optional set of tags of the package.</param>
-        /// <param name="title">An optional title of the package.</param>
-        /// <returns>The <see cref="ManifestMetadata" /> for the package.</returns>
-#else
         /// <summary>
         /// Gets the <see cref="ManifestMetadata" /> for a package.
         /// </summary>
@@ -265,7 +198,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="tags">An optional set of tags of the package.</param>
         /// <param name="title">An optional title of the package.</param>
         /// <returns>The <see cref="ManifestMetadata" /> for the package.</returns>
-#endif
         private static ManifestMetadata GetManifestMetadata(
             string name,
             string version,
@@ -273,9 +205,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             string description = null,
             string copyright = null,
             bool developmentDependency = false,
-#if !NET46
             string icon = null,
-#endif
             string iconUrl = null,
             string language = null,
             string licenseUrl = null,
@@ -300,9 +230,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
                 Copyright = copyright,
                 Description = description ?? "Description",
                 DevelopmentDependency = developmentDependency,
-#if !NET46
                 Icon = icon,
-#endif
                 Id = name,
                 Language = language,
                 LicenseMetadata = licenseMetadata,

--- a/src/MSBuildProjectCreator/PackageRepository.Library.cs
+++ b/src/MSBuildProjectCreator/PackageRepository.Library.cs
@@ -100,13 +100,13 @@ namespace {name}
         private void CreateAssembly(FileInfo fileInfo, string name, string code, IEnumerable<string> references, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
         {
             CSharpCompilation compilation = CSharpCompilation.Create(
-                name,
-                new[]
+                assemblyName: name,
+                syntaxTrees: new[]
                 {
                     CSharpSyntaxTree.ParseText(code),
                 },
-                references.Select(i => MetadataReference.CreateFromFile(i)),
-                new CSharpCompilationOptions(outputKind));
+                references: references.Select(i => MetadataReference.CreateFromFile(i)),
+                options: new CSharpCompilationOptions(outputKind));
 
             EmitResult result = compilation.Emit(fileInfo.FullName);
 

--- a/src/MSBuildProjectCreator/PackageRepository.Package.cs
+++ b/src/MSBuildProjectCreator/PackageRepository.Package.cs
@@ -21,41 +21,18 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// </summary>
         public IReadOnlyCollection<PackageIdentity> Packages => _packages;
 
-        /// <inheritdoc cref="VersionFolderPathResolver.GetInstallPath" />
+        /// <inheritdoc cref="NuGet.Packaging.VersionFolderPathResolver" />
         public string GetInstallPath(string packageId, NuGetVersion version)
         {
-            return _versionFolderPathResolver.GetInstallPath(packageId, version);
+            return VersionFolderPathResolver.GetInstallPath(packageId, version);
         }
 
-#if NET46
-        /// <summary>
-        /// Creates a new package.
-        /// </summary>
-        /// <param name="name">The name or ID of the package.</param>
-        /// <param name="version">The semantic version of the package.</param>
-        /// <param name="authors">An optional semicolon delimited list of authors of the package.  The default value is &quot;UserA&quot;</param>
-        /// <param name="description">An optional description of the package.  The default value is &quot;Description&quot;</param>
-        /// <param name="copyright">An optional copyright of the package.</param>
-        /// <param name="developmentDependency">An optional value indicating whether or not the package is a development dependency.  The default value is <code>false</code>.</param>
-        /// <param name="iconUrl">An optional URL to the icon of the package.</param>
-        /// <param name="language">An optional language of the package.</param>
-        /// <param name="licenseUrl">An optional URL to the license of the package.</param>
-        /// <param name="licenseMetadata">An optional <see cref="LicenseMetadata" /> of the package.</param>
-        /// <param name="owners">An optional semicolon delimited list of owners of the package.</param>
-        /// <param name="packageTypes">An optional <see cref="IEnumerable{PackageType}" /> containing the package types of the package.</param>
-        /// <param name="projectUrl">An optional URL to the project of the package.</param>
-        /// <param name="releaseNotes">An optional value specifying release notes of the package.</param>
-        /// <param name="repositoryType">An optional value specifying the type of source code repository of the package.</param>
-        /// <param name="repositoryUrl">An optional value specifying the URL of the source code repository of the package.</param>
-        /// <param name="repositoryBranch">An optional value specifying the branch of the source code repository of the package.</param>
-        /// <param name="repositoryCommit">An optional value specifying the commit of the source code repository of the package.</param>
-        /// <param name="requireLicenseAcceptance">An optional value indicating whether or not the package requires license acceptance  The default value is <code>false</code>.</param>
-        /// <param name="serviceable">An option value indicating whether or not the package is serviceable.  The default value is <code>false</code>.</param>
-        /// <param name="summary">An optional summary of the package.</param>
-        /// <param name="tags">An optional set of tags of the package.</param>
-        /// <param name="title">An optional title of the package.</param>
-        /// <returns>The current <see cref="PackageRepository" />.</returns>
-#else
+        /// <inheritdoc cref="NuGet.Packaging.VersionFolderPathResolver.GetManifestFilePath" />
+        public string GetManifestFilePath(string packageId, NuGetVersion version)
+        {
+            return VersionFolderPathResolver.GetManifestFilePath(packageId, version);
+        }
+
         /// <summary>
         /// Creates a new package.
         /// </summary>
@@ -84,8 +61,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="tags">An optional set of tags of the package.</param>
         /// <param name="title">An optional title of the package.</param>
         /// <returns>The current <see cref="PackageRepository" />.</returns>
-#endif
-
         public PackageRepository Package(
             string name,
             string version,
@@ -93,9 +68,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             string description = null,
             string copyright = null,
             bool developmentDependency = false,
-#if !NET46
             string icon = null,
-#endif
             string iconUrl = null,
             string language = null,
             string licenseUrl = null,
@@ -122,9 +95,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
                 description,
                 copyright,
                 developmentDependency,
-#if !NET46
                 icon,
-#endif
                 iconUrl,
                 language,
                 licenseUrl,
@@ -144,36 +115,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation
                 title);
         }
 
-#if NET46
-        /// <summary>
-        /// Creates a new package.
-        /// </summary>
-        /// <param name="name">The name or ID of the package.</param>
-        /// <param name="version">The semantic version of the package.</param>
-        /// <param name="package">Receives the <see cref="PackageIdentity" /> of the package.</param>
-        /// <param name="authors">An optional semicolon delimited list of authors of the package.  The default value is &quot;UserA&quot;</param>
-        /// <param name="description">An optional description of the package.  The default value is &quot;Description&quot;</param>
-        /// <param name="copyright">An optional copyright of the package.</param>
-        /// <param name="developmentDependency">An optional value indicating whether or not the package is a development dependency.  The default value is <code>false</code>.</param>
-        /// <param name="iconUrl">An optional URL to the icon of the package.</param>
-        /// <param name="language">An optional language of the package.</param>
-        /// <param name="licenseUrl">An optional URL to the license of the package.</param>
-        /// <param name="licenseMetadata">An optional <see cref="LicenseMetadata" /> of the package.</param>
-        /// <param name="owners">An optional semicolon delimited list of owners of the package.</param>
-        /// <param name="packageTypes">An optional <see cref="IEnumerable{PackageType}" /> containing the package types of the package.</param>
-        /// <param name="projectUrl">An optional URL to the project of the package.</param>
-        /// <param name="releaseNotes">An optional value specifying release notes of the package.</param>
-        /// <param name="repositoryType">An optional value specifying the type of source code repository of the package.</param>
-        /// <param name="repositoryUrl">An optional value specifying the URL of the source code repository of the package.</param>
-        /// <param name="repositoryBranch">An optional value specifying the branch of the source code repository of the package.</param>
-        /// <param name="repositoryCommit">An optional value specifying the commit of the source code repository of the package.</param>
-        /// <param name="requireLicenseAcceptance">An optional value indicating whether or not the package requires license acceptance  The default value is <code>false</code>.</param>
-        /// <param name="serviceable">An option value indicating whether or not the package is serviceable.  The default value is <code>false</code>.</param>
-        /// <param name="summary">An optional summary of the package.</param>
-        /// <param name="tags">An optional set of tags of the package.</param>
-        /// <param name="title">An optional title of the package.</param>
-        /// <returns>The current <see cref="PackageRepository" />.</returns>
-#else
         /// <summary>
         /// Creates a new package.
         /// </summary>
@@ -203,7 +144,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="tags">An optional set of tags of the package.</param>
         /// <param name="title">An optional title of the package.</param>
         /// <returns>The current <see cref="PackageRepository" />.</returns>
-#endif
         public PackageRepository Package(
             string name,
             string version,
@@ -212,9 +152,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             string description = null,
             string copyright = null,
             bool developmentDependency = false,
-#if !NET46
             string icon = null,
-#endif
             string iconUrl = null,
             string language = null,
             string licenseUrl = null,
@@ -245,7 +183,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
 
             package = new PackageIdentity(name, NuGetVersion.Parse(version));
 
-            string manifestFilePath = _versionFolderPathResolver.GetManifestFilePath(package.Id, package.Version);
+            string manifestFilePath = VersionFolderPathResolver.GetManifestFilePath(package.Id, package.Version);
 
             if (System.IO.File.Exists(manifestFilePath))
             {
@@ -260,9 +198,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
                 description,
                 copyright,
                 developmentDependency,
-#if !NET46
                 icon,
-#endif
                 iconUrl,
                 language,
                 licenseUrl,

--- a/src/MSBuildProjectCreator/PackageRepository.cs
+++ b/src/MSBuildProjectCreator/PackageRepository.cs
@@ -6,15 +6,16 @@ using NuGet.Configuration;
 using NuGet.Packaging;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace Microsoft.Build.Utilities.ProjectCreation
 {
     /// <summary>
     /// Represents a NuGet package repository.
     /// </summary>
-    public partial class PackageRepository
+    public partial class PackageRepository : IDisposable
     {
-        private readonly VersionFolderPathResolver _versionFolderPathResolver;
+        private readonly string _nugetPackagesGlobalFolderBackup = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
 
         private PackageManifest _packageManifest;
 
@@ -22,15 +23,30 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         {
             GlobalPackagesFolder = Path.Combine(rootPath, ".nuget", SettingsUtility.DefaultGlobalPackagesFolderPath);
 
-            _versionFolderPathResolver = new VersionFolderPathResolver(GlobalPackagesFolder);
+            VersionFolderPathResolver = new VersionFolderPathResolver(GlobalPackagesFolder);
 
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", GlobalPackagesFolder);
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", null);
+
+            ISettings settings = new Settings(rootPath, Settings.DefaultSettingsFileName);
+
+            SettingsUtility.SetConfigValue(settings, ConfigurationConstants.GlobalPackagesFolder, GlobalPackagesFolder);
+
+            settings.Remove(ConfigurationConstants.PackageSources, settings.GetSection(ConfigurationConstants.PackageSources).Items.First());
+
+            settings.AddOrUpdate(ConfigurationConstants.PackageSources, new ClearItem());
+
+            settings.SaveToDisk();
         }
 
         /// <summary>
         /// Gets the full path to the global packages folder.
         /// </summary>
         public string GlobalPackagesFolder { get; }
+
+        /// <summary>
+        /// Gets a <see cref="VersionFolderPathResolver" /> for the current package repository.
+        /// </summary>
+        private VersionFolderPathResolver VersionFolderPathResolver { get; }
 
         /// <summary>
         /// Creates a new <see cref="PackageRepository" /> instance.
@@ -40,6 +56,12 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         public static PackageRepository Create(string rootPath)
         {
             return new PackageRepository(rootPath);
+        }
+
+        /// <inheritdoc cref="IDisposable.Dispose" />
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", _nugetPackagesGlobalFolderBackup);
         }
     }
 }

--- a/src/MSBuildProjectCreator/ProjectCreator.Build.cs
+++ b/src/MSBuildProjectCreator/ProjectCreator.Build.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="globalProperties">Global properties to use when building the target.</param>
         /// <param name="result">A value indicating the result of the build.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
-        public ProjectCreator TryBuild(string target, Dictionary<string, string> globalProperties, out bool result)
+        public ProjectCreator TryBuild(string target, IDictionary<string, string> globalProperties, out bool result)
         {
             return TryBuild(restore: false, target, globalProperties, out result);
         }
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="globalProperties">Global properties to use when building the target.</param>
         /// <param name="result">A value indicating the result of the build.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
-        public ProjectCreator TryBuild(bool restore, string target, Dictionary<string, string> globalProperties, out bool result)
+        public ProjectCreator TryBuild(bool restore, string target, IDictionary<string, string> globalProperties, out bool result)
         {
             if (restore)
             {
@@ -92,7 +92,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="result">A value indicating the result of the build.</param>
         /// <param name="buildOutput">A <see cref="BuildOutput"/> object that captured the logging from the build.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
-        public ProjectCreator TryBuild(string target, Dictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput)
+        public ProjectCreator TryBuild(string target, IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput)
         {
             return TryBuild(restore: false, target, globalProperties, out result, out buildOutput);
         }
@@ -119,7 +119,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="result">A value indicating the result of the build.</param>
         /// <param name="buildOutput">A <see cref="BuildOutput"/> object that captured the logging from the build.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
-        public ProjectCreator TryBuild(bool restore, string target, Dictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput)
+        public ProjectCreator TryBuild(bool restore, string target, IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput)
         {
             buildOutput = BuildOutput.Create();
 
@@ -167,7 +167,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="globalProperties">Global properties to use when building the target.</param>
         /// <param name="result">A value indicating the result of the build.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
-        public ProjectCreator TryBuild(bool restore, Dictionary<string, string> globalProperties, out bool result)
+        public ProjectCreator TryBuild(bool restore, IDictionary<string, string> globalProperties, out bool result)
         {
             if (restore)
             {
@@ -192,7 +192,19 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
         public ProjectCreator TryBuild(out bool result, out BuildOutput buildOutput)
         {
-            return TryBuild(restore: false, out result, out buildOutput);
+            return TryBuild(globalProperties: null, out result, out buildOutput);
+        }
+
+        /// <summary>
+        /// Attempts to build the current project.
+        /// </summary>
+        /// <param name="globalProperties">Global properties to use when building the target.</param>
+        /// <param name="result">A value indicating the result of the build.</param>
+        /// <param name="buildOutput">A <see cref="BuildOutput"/> object that captured the logging from the build.</param>
+        /// <returns>The current <see cref="ProjectCreator"/>.</returns>
+        public ProjectCreator TryBuild(IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput)
+        {
+            return TryBuild(restore: false, globalProperties, out result, out buildOutput);
         }
 
         /// <summary>
@@ -215,7 +227,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="result">A value indicating the result of the build.</param>
         /// <param name="buildOutput">A <see cref="BuildOutput"/> object that captured the logging from the build.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
-        public ProjectCreator TryBuild(bool restore, Dictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput)
+        public ProjectCreator TryBuild(bool restore, IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput)
         {
             buildOutput = BuildOutput.Create();
 
@@ -246,7 +258,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="buildOutput">A <see cref="BuildOutput"/> object that captured the logging from the build.</param>
         /// <param name="targetOutputs">A <see cref="IDictionary{String,TargetResult}" /> containing the target outputs.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
-        public ProjectCreator TryBuild(string target, Dictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
+        public ProjectCreator TryBuild(string target, IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
         {
             return TryBuild(restore: false, target, out result, out buildOutput, out targetOutputs);
         }
@@ -275,7 +287,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="buildOutput">A <see cref="BuildOutput"/> object that captured the logging from the build.</param>
         /// <param name="targetOutputs">A <see cref="IDictionary{String,TargetResult}" /> containing the target outputs.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
-        public ProjectCreator TryBuild(bool restore, string target, Dictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
+        public ProjectCreator TryBuild(bool restore, string target, IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
         {
             return TryBuild(restore, new[] { target }, out result, out buildOutput, out targetOutputs);
         }
@@ -302,7 +314,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="buildOutput">A <see cref="BuildOutput"/> object that captured the logging from the build.</param>
         /// <param name="targetOutputs">A <see cref="IDictionary{String,TargetResult}" /> containing the target outputs.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
-        public ProjectCreator TryBuild(string[] targets, Dictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
+        public ProjectCreator TryBuild(string[] targets, IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
         {
             return TryBuild(restore: false, targets, out result, out buildOutput, out targetOutputs);
         }
@@ -331,7 +343,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="buildOutput">A <see cref="BuildOutput"/> object that captured the logging from the build.</param>
         /// <param name="targetOutputs">A <see cref="IDictionary{String,TargetResult}" /> containing the target outputs.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
-        public ProjectCreator TryBuild(bool restore, string[] targets, Dictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
+        public ProjectCreator TryBuild(bool restore, string[] targets, IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
         {
             buildOutput = BuildOutput.Create();
 
@@ -362,7 +374,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="buildOutput">A <see cref="BuildOutput"/> object that captured the logging from the build.</param>
         /// <param name="targetOutputs">A <see cref="IDictionary{String,TargetResult}" /> containing the target outputs.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
-        public ProjectCreator TryBuild(IEnumerable<string> targets, Dictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
+        public ProjectCreator TryBuild(IEnumerable<string> targets, IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
         {
             return TryBuild(restore: false, targets, globalProperties, out result, out buildOutput, out targetOutputs);
         }
@@ -391,9 +403,9 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="buildOutput">A <see cref="BuildOutput"/> object that captured the logging from the build.</param>
         /// <param name="targetOutputs">A <see cref="IDictionary{String,TargetResult}" /> containing the target outputs.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
-        public ProjectCreator TryBuild(bool restore, IEnumerable<string> targets, Dictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
+        public ProjectCreator TryBuild(bool restore, IEnumerable<string> targets, IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
         {
-            return TryBuild(restore, targets.ToArray(), out result, out buildOutput, out targetOutputs);
+            return TryBuild(restore, targets.ToArray(), globalProperties, out result, out buildOutput, out targetOutputs);
         }
 
         /// <summary>
@@ -403,7 +415,18 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
         public ProjectCreator TryRestore(out bool result)
         {
-            return TryRestore(out result, out BuildOutput _, out IDictionary<string, TargetResult> _);
+            return TryRestore(null, out result);
+        }
+
+        /// <summary>
+        /// Attempts to run the Restore target for the current project with a unique evaluation context.
+        /// </summary>
+        /// <param name="globalProperties">Global properties to use when running the Restore the target.</param>
+        /// <param name="result">A value indicating the result of the restore.</param>
+        /// <returns>The current <see cref="ProjectCreator"/>.</returns>
+        public ProjectCreator TryRestore(IDictionary<string, string> globalProperties, out bool result)
+        {
+            return TryRestore(globalProperties, out result, out BuildOutput _, out IDictionary<string, TargetResult> _);
         }
 
         /// <summary>
@@ -414,7 +437,19 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
         public ProjectCreator TryRestore(out bool result, out BuildOutput buildOutput)
         {
-            return TryRestore(out result, out buildOutput, out IDictionary<string, TargetResult> _);
+            return TryRestore(null, out result, out buildOutput);
+        }
+
+        /// <summary>
+        /// Attempts to run the Restore target for the current project with a unique evaluation context.
+        /// </summary>
+        /// <param name="globalProperties">Global properties to use when running the Restore the target.</param>
+        /// <param name="result">A value indicating the result of the restore.</param>
+        /// <param name="buildOutput">A <see cref="BuildOutput"/> object that captured the logging from the restore.</param>
+        /// <returns>The current <see cref="ProjectCreator"/>.</returns>
+        public ProjectCreator TryRestore(IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput)
+        {
+            return TryRestore(globalProperties, out result, out buildOutput, out IDictionary<string, TargetResult> _);
         }
 
         /// <summary>
@@ -425,6 +460,19 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="targetOutputs">A <see cref="IDictionary{String,TargetResult}" /> containing the target outputs.</param>
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
         public ProjectCreator TryRestore(out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
+        {
+            return TryRestore(null, out result, out buildOutput, out targetOutputs);
+        }
+
+        /// <summary>
+        /// Attempts to run the Restore target for the current project with a unique evaluation context.
+        /// </summary>
+        /// <param name="globalProperties">Global properties to use when running the Restore the target.</param>
+        /// <param name="result">A value indicating the result of the restore.</param>
+        /// <param name="buildOutput">A <see cref="BuildOutput"/> object that captured the logging from the restore.</param>
+        /// <param name="targetOutputs">A <see cref="IDictionary{String,TargetResult}" /> containing the target outputs.</param>
+        /// <returns>The current <see cref="ProjectCreator"/>.</returns>
+        public ProjectCreator TryRestore(IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
         {
             buildOutput = BuildOutput.Create();
 
@@ -439,7 +487,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
 
                 try
                 {
-                    Restore(out result, out targetOutputs);
+                    Restore(globalProperties, out result, out targetOutputs);
                 }
                 finally
                 {
@@ -450,14 +498,14 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             return this;
         }
 
-        private void Build(string[] targets, Dictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
+        private void Build(string[] targets, IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
         {
             buildOutput = BuildOutput.Create();
 
             Build(restore: false, targets, globalProperties, buildOutput, out result, out targetOutputs);
         }
 
-        private void Build(bool restore, string[] targets, Dictionary<string, string> globalProperties, BuildOutput buildOutput, out bool result, out IDictionary<string, TargetResult> targetOutputs)
+        private void Build(bool restore, string[] targets, IDictionary<string, string> globalProperties, BuildOutput buildOutput, out bool result, out IDictionary<string, TargetResult> targetOutputs)
         {
             targetOutputs = null;
 
@@ -530,11 +578,11 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             }
         }
 
-        private void Restore(out bool result, out IDictionary<string, TargetResult> targetOutputs)
+        private void Restore(IDictionary<string, string> globalProperties, out bool result, out IDictionary<string, TargetResult> targetOutputs)
         {
             Save();
 
-            IDictionary<string, string> globalProperties = new Dictionary<string, string>(ProjectCollection.GlobalProperties);
+            globalProperties = globalProperties ?? new Dictionary<string, string>(ProjectCollection.GlobalProperties);
 
             globalProperties["ExcludeRestorePackageImports"] = "true";
             globalProperties["MSBuildRestoreSessionId"] = Guid.NewGuid().ToString("D");
@@ -560,6 +608,11 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             targetOutputs = buildResult.ResultsByTarget;
 
             result = buildResult.OverallResult == BuildResultCode.Success;
+        }
+
+        private void Restore(out bool result, out IDictionary<string, TargetResult> targetOutputs)
+        {
+            Restore(null, out result, out targetOutputs);
         }
     }
 }

--- a/src/MSBuildProjectCreator/ProjectCreatorException.cs
+++ b/src/MSBuildProjectCreator/ProjectCreatorException.cs
@@ -3,9 +3,6 @@
 // Licensed under the MIT license.
 
 using System;
-#if NET46
-using System.Runtime.Serialization;
-#endif
 
 namespace Microsoft.Build.Utilities.ProjectCreation
 {
@@ -32,17 +29,5 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             : base(message, innerException)
         {
         }
-
-#if NET46
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ProjectCreatorException"/> class.
-        /// </summary>
-        /// <param name="info">The <see cref="SerializationInfo"/> of the exception.</param>
-        /// <param name="context">The <see cref="StreamingContext"/> of the exception.</param>
-        protected ProjectCreatorException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
-#endif
     }
 }


### PR DESCRIPTION
Package repositories were not as isolated as I wanted.  PackageRepository objects are now `IDisposable` and this is the only context in which they work.

Updated documentation and unit tests