### PR TITLE
Fix assembly binding

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         dotnet-version: ${{ env.DotNet5Version }}
 
-    - name: Build
+    - name: Build Solution
       run: dotnet build "/p:Platform=${{ env.BuildPlatform }}" "/p:Configuration=${{ env.BuildConfiguration }}" "/BinaryLogger:${{ env.ArtifactsDirectoryName }}\msbuild.binlog"
       
     - name: Run Unit Tests (.NET Core 3.1)
@@ -86,7 +86,7 @@ jobs:
       with:
         dotnet-version: ${{ env.DotNet5Version }}
     
-    - name: Build
+    - name: Build Solution
       run: dotnet build "/p:Platform=${{ env.BuildPlatform }}" "/p:Configuration=${{ env.BuildConfiguration }}" "/BinaryLogger:${{ env.ArtifactsDirectoryName }}\msbuild.binlog"
       
     - name: Run Unit Tests (.NET Core 3.1)
@@ -130,7 +130,7 @@ jobs:
       with:
         dotnet-version: ${{ env.DotNet5Version }}
     
-    - name: Build
+    - name: Build Solution
       run: dotnet build "/p:Platform=${{ env.BuildPlatform }}" "/p:Configuration=${{ env.BuildConfiguration }}" "/BinaryLogger:${{ env.ArtifactsDirectoryName }}\msbuild.binlog"
 
     - name: Run Unit Tests (.NET Core 3.1)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ env:
   ArtifactsDirectoryName: 'artifacts'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'Any CPU'
+  DotNet3Version: '3.x'
   DotNet5Version: '5.x'
 
 jobs:
@@ -28,13 +29,21 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core
+    - name: Install .NET Core ${{ env.DotNet3Version }}
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DotNet3Version }}
+
+    - name: Install .NET ${{ env.DotNet5Version }}
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.DotNet5Version }}
 
     - name: Build
       run: dotnet build "/p:Platform=${{ env.BuildPlatform }}" "/p:Configuration=${{ env.BuildConfiguration }}" "/BinaryLogger:${{ env.ArtifactsDirectoryName }}\msbuild.binlog"
+      
+    - name: Run Unit Tests (.NET Core 3.1)
+      run: dotnet test --logger trx --no-restore --no-build --framework netcoreapp3.1 /restore:false
       
     - name: Run Unit Tests (.NET 5)
       run: dotnet test --logger trx --no-restore --no-build --framework net5.0 /restore:false
@@ -67,7 +76,12 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core
+    - name: Install .NET Core ${{ env.DotNet3Version }}
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DotNet3Version }}
+
+    - name: Install .NET ${{ env.DotNet5Version }}
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.DotNet5Version }}
@@ -75,6 +89,9 @@ jobs:
     - name: Build
       run: dotnet build "/p:Platform=${{ env.BuildPlatform }}" "/p:Configuration=${{ env.BuildConfiguration }}" "/BinaryLogger:${{ env.ArtifactsDirectoryName }}\msbuild.binlog"
       
+    - name: Run Unit Tests (.NET Core 3.1)
+      run: dotnet test --logger trx --no-restore --no-build --framework netcoreapp3.1 /restore:false
+
     - name: Run Unit Tests (.NET 5)
       run: dotnet test --logger trx --no-restore --no-build --framework net5.0 /restore:false
 
@@ -103,14 +120,22 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core
+    - name: Install .NET Core ${{ env.DotNet3Version }}
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DotNet3Version }}
+
+    - name: Install .NET ${{ env.DotNet5Version }}
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.DotNet5Version }}
     
     - name: Build
       run: dotnet build "/p:Platform=${{ env.BuildPlatform }}" "/p:Configuration=${{ env.BuildConfiguration }}" "/BinaryLogger:${{ env.ArtifactsDirectoryName }}\msbuild.binlog"
-      
+
+    - name: Run Unit Tests (.NET Core 3.1)
+      run: dotnet test --logger trx --no-restore --no-build --framework netcoreapp3.1 /restore:false
+
     - name: Run Unit Tests (.NET 5)
       run: dotnet test --logger trx --no-restore --no-build --framework net5.0 /restore:false
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,5 +7,6 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)key.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);SA1005;SA1512</NoWarn>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/MSBuildProjectCreator.sln
+++ b/MSBuildProjectCreator.sln
@@ -26,6 +26,16 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{8339FD67
 		xunit.runner.json = xunit.runner.json
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{3F239E9A-CEB8-410A-BA63-4F860B9566E6}"
+	ProjectSection(SolutionItems) = preProject
+		.github\dependabot.yml = .github\dependabot.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{B7A3C6A3-30B4-4B86-8434-5865A70E2D7C}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\CI.yml = .github\workflows\CI.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +53,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B7A3C6A3-30B4-4B86-8434-5865A70E2D7C} = {3F239E9A-CEB8-410A-BA63-4F860B9566E6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {570C6638-0C7D-40C6-90CF-2F02FACB2CD2}

--- a/Packages.props
+++ b/Packages.props
@@ -15,6 +15,9 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Update="Microsoft.Build" Version="16.9.0" />
+    <PackageReference Update="NuGet.Frameworks" Version="5.7.1" />
+    <PackageReference Update="NuGet.Packaging" Version="5.7.1" />
+    <PackageReference Update="NuGet.ProjectModel" Version="5.7.1" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="2.2.0" />

--- a/Packages.props
+++ b/Packages.props
@@ -13,7 +13,9 @@
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
-  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Update="Microsoft.Build" Version="16.9.0" />
+  </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="2.2.0" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.4.220" Condition=" '$(EnableGitVersioning)' != 'false' " />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ jobs:
       version: '$(DotNet5Version)'
 
   - task: DotNetCoreCLI@2
-    displayName: 'dotnet build'
+    displayName: 'Build Solution'
     inputs:
       command: 'build'
       arguments: '$(MSBuildArgs)'
@@ -139,7 +139,7 @@ jobs:
       version: '$(DotNet5Version)'
 
   - task: DotNetCoreCLI@2
-    displayName: 'dotnet build'
+    displayName: 'Build Solution'
     inputs:
       command: 'build'
       arguments: '$(MSBuildArgs)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ variables:
   ArtifactsDirectoryName: 'artifacts'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'Any CPU'
+  DotNet3Version: '3.x'
   DotNet5Version: '5.x'
   MSBuildArgs: '"/p:Platform=$(BuildPlatform)" "/p:Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
   
@@ -35,6 +36,11 @@ jobs:
     vmImage: windows-latest
   steps:
   - task: UseDotNet@2
+    displayName: 'Install .NET Core $(DotNet3Version)'
+    inputs:
+      version: '$(DotNet3Version)'
+
+  - task: UseDotNet@2
     displayName: 'Install .NET $(DotNet5Version)'
     inputs:
       version: '$(DotNet5Version)'
@@ -45,6 +51,13 @@ jobs:
       command: 'build'
       projects: 'MSBuildProjectCreator.sln'
       arguments: '$(MSBuildArgs)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET Core 3.1)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework netcoreapp3.1 "/restore:false"'
+      testRunTitle: 'Windows .NET 3.1'
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests (.NET 5)'
@@ -74,7 +87,12 @@ jobs:
     vmImage: ubuntu-latest
   steps:
   - task: UseDotNet@2
-    displayName: 'Install .NET Core $(DotNet5Version)'
+    displayName: 'Install .NET Core $(DotNet3Version)'
+    inputs:
+      version: '$(DotNet3Version)'
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET $(DotNet5Version)'
     inputs:
       version: '$(DotNet5Version)'
 
@@ -83,6 +101,13 @@ jobs:
     inputs:
       command: 'build'
       arguments: '$(MSBuildArgs)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET Core 3.1)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework netcoreapp3.1 "/restore:false"'
+      testRunTitle: 'Linux .NET Core 3.1'
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests (.NET 5)'
@@ -104,7 +129,12 @@ jobs:
     vmImage: macOS-latest
   steps:
   - task: UseDotNet@2
-    displayName: 'Install .NET Core $(DotNet5Version)'
+    displayName: 'Install .NET Core $(DotNet3Version)'
+    inputs:
+      version: '$(DotNet3Version)'
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET $(DotNet5Version)'
     inputs:
       version: '$(DotNet5Version)'
 
@@ -113,6 +143,13 @@ jobs:
     inputs:
       command: 'build'
       arguments: '$(MSBuildArgs)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET Core 3.1)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework netcoreapp3.1 "/restore:false"'
+      testRunTitle: 'MacOS .NET Core 3.1'
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests (.NET 5)'

--- a/src/MSBuildProjectCreator.UnitTests/MSBuildProjectCreator.UnitTests.csproj
+++ b/src/MSBuildProjectCreator.UnitTests/MSBuildProjectCreator.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Build.Utilities.ProjectCreation.UnitTests</AssemblyName>
     <RootNamespace>Microsoft.Build.Utilities.ProjectCreation.UnitTests</RootNamespace>

--- a/src/MSBuildProjectCreator.UnitTests/PackageRepositoryTests/PackageTests.cs
+++ b/src/MSBuildProjectCreator.UnitTests/PackageRepositoryTests/PackageTests.cs
@@ -19,14 +19,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageRepositoryT
         [Fact]
         public void BuildCanConsumePackage()
         {
-            const string targetFramework =
-#if NETCOREAPP3_1
-                "netcoreapp3.1";
-#elif NETFRAMEWORK
-                "net472";
-#else
-                "net5.0";
-#endif
             using (PackageRepository.Create(TestRootPath)
                 .Package("PackageB", "1.0", out PackageIdentity packageB)
                     .Library("netstandard2.0")
@@ -35,7 +27,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageRepositoryT
                     .Library("netstandard2.0"))
             {
                 ProjectCreator.Templates.SdkCsproj(
-                        targetFramework: targetFramework)
+                        targetFramework: TargetFramework)
                     .ItemPackageReference(packageA)
                     .Save(Path.Combine(TestRootPath, "ClassLibraryA", "ClassLibraryA.csproj"))
                     .TryBuild(restore: true, out bool result, out BuildOutput buildOutput);

--- a/src/MSBuildProjectCreator.UnitTests/PackageRepositoryTests/PackageTests.cs
+++ b/src/MSBuildProjectCreator.UnitTests/PackageRepositoryTests/PackageTests.cs
@@ -19,6 +19,14 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageRepositoryT
         [Fact]
         public void BuildCanConsumePackage()
         {
+            const string targetFramework =
+#if NETCOREAPP3_1
+                "netcoreapp3.1";
+#elif NETFRAMEWORK
+                "net472";
+#else
+                "net5.0";
+#endif
             using (PackageRepository.Create(TestRootPath)
                 .Package("PackageB", "1.0", out PackageIdentity packageB)
                     .Library("netstandard2.0")
@@ -27,7 +35,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageRepositoryT
                     .Library("netstandard2.0"))
             {
                 ProjectCreator.Templates.SdkCsproj(
-                        targetFramework: "net5.0")
+                        targetFramework: targetFramework)
                     .ItemPackageReference(packageA)
                     .Save(Path.Combine(TestRootPath, "ClassLibraryA", "ClassLibraryA.csproj"))
                     .TryBuild(restore: true, out bool result, out BuildOutput buildOutput);

--- a/src/MSBuildProjectCreator.UnitTests/SdkCsprojTests.cs
+++ b/src/MSBuildProjectCreator.UnitTests/SdkCsprojTests.cs
@@ -5,15 +5,36 @@
 using Microsoft.Build.Evaluation;
 using Shouldly;
 using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
 {
     public class SdkCsprojTests : TestBase
     {
+        private readonly ITestOutputHelper _testOutput;
+
+        public SdkCsprojTests(ITestOutputHelper testOutput)
+        {
+            _testOutput = testOutput;
+        }
+
         [Fact]
         public void CanBuild()
         {
+            foreach (DictionaryEntry dictionaryEntry in Environment.GetEnvironmentVariables().Cast<DictionaryEntry>().OrderBy(i => (string)i.Key))
+            {
+                _testOutput.WriteLine($"{dictionaryEntry.Key}={dictionaryEntry.Value}");
+            }
+
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies().Where(i => !i.IsDynamic).OrderBy(i => i.FullName))
+            {
+                _testOutput.WriteLine($"{assembly.FullName} / {assembly.Location}");
+            }
+
             const string targetFramework = "net472";
 
             ProjectCreator.Templates.SdkCsproj(

--- a/src/MSBuildProjectCreator.UnitTests/SdkCsprojTests.cs
+++ b/src/MSBuildProjectCreator.UnitTests/SdkCsprojTests.cs
@@ -15,30 +15,11 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
 {
     public class SdkCsprojTests : TestBase
     {
-        private readonly ITestOutputHelper _testOutput;
-
-        public SdkCsprojTests(ITestOutputHelper testOutput)
-        {
-            _testOutput = testOutput;
-        }
-
         [Fact]
         public void CanBuild()
         {
-            foreach (DictionaryEntry dictionaryEntry in Environment.GetEnvironmentVariables().Cast<DictionaryEntry>().OrderBy(i => (string)i.Key))
-            {
-                _testOutput.WriteLine($"{dictionaryEntry.Key}={dictionaryEntry.Value}");
-            }
-
-            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies().Where(i => !i.IsDynamic).OrderBy(i => i.FullName))
-            {
-                _testOutput.WriteLine($"{assembly.FullName} / {assembly.Location}");
-            }
-
-            const string targetFramework = "net472";
-
             ProjectCreator.Templates.SdkCsproj(
-                    targetFramework: targetFramework,
+                    targetFramework: TargetFramework,
                     path: GetTempFileName(".csproj"))
                 .Save()
                 .TryBuild(restore: true, "Build", out bool result, out BuildOutput buildOutput);

--- a/src/MSBuildProjectCreator.UnitTests/TestBase.cs
+++ b/src/MSBuildProjectCreator.UnitTests/TestBase.cs
@@ -12,15 +12,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
         protected TestBase()
         {
             TestRootPath = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())).FullName;
-
-            File.WriteAllText(
-                Path.Combine(TestRootPath, "global.json"),
-                @"{
-   ""sdk"": {
-    ""version"": ""5.0.100"",
-    ""rollForward"": ""latestMinor""
-  }
-}");
         }
 
         public string TestRootPath { get; }

--- a/src/MSBuildProjectCreator.UnitTests/TestBase.cs
+++ b/src/MSBuildProjectCreator.UnitTests/TestBase.cs
@@ -14,6 +14,18 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
             TestRootPath = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())).FullName;
         }
 
+        public string TargetFramework
+        {
+            get =>
+#if NETCOREAPP3_1
+            "netcoreapp3.1";
+#elif NET5_0
+            "net5.0";
+#else
+            "net472";
+#endif
+        }
+
         public string TestRootPath { get; }
 
         public void Dispose()

--- a/src/MSBuildProjectCreator/MSBuildAssemblyResolver.cs
+++ b/src/MSBuildProjectCreator/MSBuildAssemblyResolver.cs
@@ -38,18 +38,26 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         private static readonly AssemblyLoadContext LoadContext = new AssemblyLoadContext(nameof(MSBuildAssemblyResolver));
 #endif
 
+        private static readonly Lazy<string> DotNetSdksPathLazy = new Lazy<string>(
+        () =>
+        {
+#if NETFRAMEWORK
+            return null;
+#else
+            return GetDotNetBasePath();
+#endif
+        });
+
         private static readonly Lazy<string[]> MSBuildDirectoryLazy = new Lazy<string[]>(
             () =>
             {
 #if !NETFRAMEWORK
-                string basePath = GetDotNetBasePath();
-
-                if (!string.IsNullOrWhiteSpace(basePath))
+                if (!string.IsNullOrWhiteSpace(DotNetSdksPath))
                 {
                     return new[]
                     {
-                        basePath,
-                        Path.Combine(basePath, "Roslyn", "bincore"),
+                        DotNetSdksPath,
+                        Path.Combine(DotNetSdksPathLazy.Value, "Roslyn", "bincore"),
                     };
                 }
 #else
@@ -97,6 +105,11 @@ namespace Microsoft.Build.Utilities.ProjectCreation
 #if NETFRAMEWORK
         private static readonly char[] PathSplitChars = { Path.PathSeparator };
 #endif
+
+        /// <summary>
+        /// Gets the path to the .NET SDKs.
+        /// </summary>
+        public static string DotNetSdksPath => DotNetSdksPathLazy.Value;
 
         /// <summary>
         /// Gets the full path to the MSBuild directory used.

--- a/src/MSBuildProjectCreator/MSBuildAssemblyResolver.cs
+++ b/src/MSBuildProjectCreator/MSBuildAssemblyResolver.cs
@@ -3,15 +3,19 @@
 // Licensed under the MIT license.
 
 using System;
+
 #if !NETFRAMEWORK
 using System.Diagnostics;
 #endif
+
 using System.IO;
 using System.Linq;
 using System.Reflection;
+#if NETCOREAPP || NET5_0_OR_GREATER
+using System.Runtime.Loader;
+#endif
 #if !NETFRAMEWORK
 using System.Text.RegularExpressions;
-using System.Threading;
 #endif
 #if NETFRAMEWORK
 using Microsoft.VisualStudio.Setup.Configuration;
@@ -24,6 +28,16 @@ namespace Microsoft.Build.Utilities.ProjectCreation
     /// </summary>
     public static class MSBuildAssemblyResolver
     {
+        private static readonly string[] AssemblyExtensions = { ".dll", ".exe" };
+
+#if !NETFRAMEWORK
+        private static readonly Regex DotNetListSdksRegex = new Regex("^(?<Name>(?<Version>\\d+\\.\\d+\\.\\d{3,4})(?<Tag>[-\\.\\w]*)) \\[(?<Directory>.*)\\]\\r?$", RegexOptions.Multiline);
+#endif
+
+#if NETCOREAPP || NET5_0_OR_GREATER
+        private static readonly AssemblyLoadContext LoadContext = new AssemblyLoadContext(nameof(MSBuildAssemblyResolver));
+#endif
+
         private static readonly Lazy<string[]> MSBuildDirectoryLazy = new Lazy<string[]>(
             () =>
             {
@@ -77,16 +91,11 @@ namespace Microsoft.Build.Utilities.ProjectCreation
                     };
                 }
 #endif
-
                 return null;
             });
 
+#if NETFRAMEWORK
         private static readonly char[] PathSplitChars = { Path.PathSeparator };
-
-        private static readonly string[] AssemblyExtensions = { ".dll", ".exe" };
-
-#if !NETFRAMEWORK
-        private static readonly Regex DotNetBasePathRegex = new Regex(@"^ Base Path:\s+(?<Path>.*)$");
 #endif
 
         /// <summary>
@@ -99,7 +108,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="args">The event data.</param>
-        /// <returns>An MSBuild assembly if one could be located, otherwise <code>null</code>.</returns>
+        /// <returns>An MSBuild assembly if one could be located, otherwise <c>null</c>.</returns>
         public static Assembly AssemblyResolve(object sender, ResolveEventArgs args)
         {
             if (SearchPaths == null)
@@ -124,103 +133,85 @@ namespace Microsoft.Build.Utilities.ProjectCreation
                     continue;
                 }
 
-                if (requestedAssemblyName.Flags.HasFlag(AssemblyNameFlags.PublicKey) && !requestedAssemblyName.GetPublicKeyToken().SequenceEqual(candidateAssemblyName.GetPublicKeyToken()))
+                if (requestedAssemblyName.Flags.HasFlag(AssemblyNameFlags.PublicKey) && !requestedAssemblyName.GetPublicKeyToken() !.SequenceEqual(candidateAssemblyName.GetPublicKeyToken() !))
                 {
                     // Requested assembly has a public key but it doesn't match the candidate assembly public key
                     continue;
                 }
-
+#if NET5_0_OR_GREATER
+                return LoadContext.LoadFromAssemblyPath(candidateAssemblyFile.FullName);
+#else
                 return Assembly.LoadFrom(candidateAssemblyFile.FullName);
+#endif
             }
 
             return null;
         }
 
 #if !NETFRAMEWORK
-
         private static string GetDotNetBasePath()
         {
-            string basePath = null;
-
-            using (ManualResetEvent processExited = new ManualResetEvent(false))
-            using (Process process = new Process
+            using Process process = new Process
             {
                 EnableRaisingEvents = true,
                 StartInfo = new ProcessStartInfo
                 {
-                    Arguments = "--info",
+                    Arguments = "--list-sdks",
                     CreateNoWindow = true,
                     FileName = "dotnet",
                     UseShellExecute = false,
                     RedirectStandardError = true,
-                    RedirectStandardInput = true,
                     RedirectStandardOutput = true,
                     WorkingDirectory = Environment.CurrentDirectory,
                 },
-            })
+            };
+
+            process.StartInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"] = "en-US";
+            process.StartInfo.EnvironmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
+            process.StartInfo.EnvironmentVariables["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+
+            try
             {
-                process.StartInfo.EnvironmentVariables["DOTNET_CLI_UI_LANGUAGE"] = "en-US";
-
-                process.ErrorDataReceived += (sender, args) => { };
-
-                process.OutputDataReceived += (sender, args) =>
-                {
-                    if (!String.IsNullOrWhiteSpace(args?.Data))
-                    {
-                        Match match = DotNetBasePathRegex.Match(args.Data);
-
-                        if (match.Success && match.Groups["Path"].Success)
-                        {
-                            basePath = match.Groups["Path"].Value.Trim();
-                        }
-                    }
-                };
-
-                process.Exited += (sender, args) => { processExited.Set(); };
-
-                try
-                {
-                    if (!process.Start())
-                    {
-                        return null;
-                    }
-                }
-                catch
+                if (!process.Start())
                 {
                     return null;
                 }
-
-                process.StandardInput.Close();
-
-                process.BeginErrorReadLine();
-                process.BeginOutputReadLine();
-
-                switch (WaitHandle.WaitAny(new WaitHandle[] { processExited }, TimeSpan.FromSeconds(5)))
-                {
-                    case WaitHandle.WaitTimeout:
-                        break;
-
-                    case 0:
-                        break;
-                }
-
-                if (!process.HasExited)
-                {
-                    try
-                    {
-                        process.Kill();
-                    }
-                    catch
-                    {
-                    }
-                }
-
-                return basePath;
             }
-        }
+            catch
+            {
+                return null;
+            }
 
+            process.WaitForExit();
+
+            DirectoryInfo GetFirstMatchingSdk(string output)
+            {
+                var match = DotNetListSdksRegex.Match(output);
+
+                while (match.Success)
+                {
+                    string versionString = match.Groups["Version"].Value.Trim();
+
+                    if (Version.TryParse(versionString, out Version version) && Environment.Version.Major == version.Major)
+                    {
+                        DirectoryInfo directoryInfo = new DirectoryInfo(Path.Combine(match.Groups["Directory"].Value.Trim(), match.Groups["Name"].Value.Trim()));
+
+                        return directoryInfo;
+                    }
+
+                    match = match.NextMatch();
+                }
+
+                return null;
+            }
+
+            DirectoryInfo basePath = GetFirstMatchingSdk(process.StandardOutput.ReadToEnd());
+
+            return basePath?.FullName;
+        }
 #endif
 
+#if NETFRAMEWORK
         private static string GetMSBuildVersionDirectory(string version)
         {
             if (Version.TryParse(version, out Version visualStudioVersion) && visualStudioVersion.Major >= 16)
@@ -230,8 +221,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation
 
             return version;
         }
-
-#if NETFRAMEWORK
 
         private static string GetPathOfFirstInstalledVisualStudioInstance()
         {
@@ -273,7 +262,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation
 
             return null;
         }
-
 #endif
     }
 }

--- a/src/MSBuildProjectCreator/MSBuildProjectCreator.csproj
+++ b/src/MSBuildProjectCreator/MSBuildProjectCreator.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <RootNamespace>Microsoft.Build.Utilities.ProjectCreation</RootNamespace>
     <AssemblyName>Microsoft.Build.Utilities.ProjectCreation</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -9,7 +9,6 @@
     <CopyArtifactsAfterTargets>Pack</CopyArtifactsAfterTargets>
     <DefaultArtifactsFileMatch>*nupkg</DefaultArtifactsFileMatch>
   </PropertyGroup>
-  
   <PropertyGroup Label="Package properties">
     <IncludeSymbols>true</IncludeSymbols>
     <PackageId>MSBuild.ProjectCreation</PackageId>
@@ -21,30 +20,21 @@
     <RepositoryUrl>https://github.com/jeffkl/MSBuildProjectCreator.git</RepositoryUrl>
     <PackageTags>MSBuild project creator generator</PackageTags>
   </PropertyGroup>
-
-  <ItemDefinitionGroup>
-    <PackageReference>
-      <ExcludeAssets>Runtime</ExcludeAssets>
-    </PackageReference>
-  </ItemDefinitionGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Condition="'$(TargetFramework)' == 'net472'" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Condition="'$(TargetFramework)' == 'net472'" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Condition="'$(TargetFramework)' == 'net472'" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="NuGet.Frameworks" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="NuGet.ProjectModel" />
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Update="Resources\Strings.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
   <ItemGroup>
     <None Include="build\MSBuild.ProjectCreation.props" Pack="true" PackagePath="build\" />
   </ItemGroup>

--- a/src/MSBuildProjectCreator/MSBuildTestBase.cs
+++ b/src/MSBuildProjectCreator/MSBuildTestBase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         {
             Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", string.IsNullOrWhiteSpace(MSBuildAssemblyResolver.DotNetSdksPath) ? null : Path.Combine(MSBuildAssemblyResolver.DotNetSdksPath, "MSBuild.dll"));
             Environment.SetEnvironmentVariable("MSBuildExtensionsPath", MSBuildAssemblyResolver.DotNetSdksPath);
-            Environment.SetEnvironmentVariable("MSBuildSdksPath", string.IsNullOrWhiteSpace(MSBuildAssemblyResolver.DotNetSdksPath) ? null : Path.Combine(MSBuildAssemblyResolver.DotNetSdksPath, "Sdks"));
+            Environment.SetEnvironmentVariable("MSBuildSDKsPath", string.IsNullOrWhiteSpace(MSBuildAssemblyResolver.DotNetSdksPath) ? null : Path.Combine(MSBuildAssemblyResolver.DotNetSdksPath, "Sdks"));
 
             AppDomain.CurrentDomain.AssemblyResolve += MSBuildAssemblyResolver.AssemblyResolve;
         }

--- a/src/MSBuildProjectCreator/MSBuildTestBase.cs
+++ b/src/MSBuildProjectCreator/MSBuildTestBase.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.IO;
 
 namespace Microsoft.Build.Utilities.ProjectCreation
 {
@@ -11,18 +12,11 @@ namespace Microsoft.Build.Utilities.ProjectCreation
     /// </summary>
     public abstract class MSBuildTestBase
     {
-        private static readonly string[] EnvironmentVariablesToRemove =
-        {
-            "MSBuildSdksPath",
-            "MSBuildExtensionsPath",
-        };
-
         static MSBuildTestBase()
         {
-            foreach (string environmentVariableName in EnvironmentVariablesToRemove)
-            {
-                Environment.SetEnvironmentVariable(environmentVariableName, null);
-            }
+            Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", string.IsNullOrWhiteSpace(MSBuildAssemblyResolver.DotNetSdksPath) ? null : Path.Combine(MSBuildAssemblyResolver.DotNetSdksPath, "MSBuild.dll"));
+            Environment.SetEnvironmentVariable("MSBuildExtensionsPath", MSBuildAssemblyResolver.DotNetSdksPath);
+            Environment.SetEnvironmentVariable("MSBuildSdksPath", string.IsNullOrWhiteSpace(MSBuildAssemblyResolver.DotNetSdksPath) ? null : Path.Combine(MSBuildAssemblyResolver.DotNetSdksPath, "Sdks"));
 
             AppDomain.CurrentDomain.AssemblyResolve += MSBuildAssemblyResolver.AssemblyResolve;
         }


### PR DESCRIPTION
Load the corresponding MSBuild for the current runtime.  If an app is .NET 5, it must use a .NET 5 MSBuild.

Also fix assembly loading for NuGet by using an AssemblyLoadContext

Rev version to 4.0