### PR TITLE
Set TargetFramework property when TargetFrameworks contains a single value

### DIFF
--- a/src/MSBuildProjectCreator.UnitTests/SdkCsprojTests.cs
+++ b/src/MSBuildProjectCreator.UnitTests/SdkCsprojTests.cs
@@ -2,14 +2,8 @@
 //
 // Licensed under the MIT license.
 
-using Microsoft.Build.Evaluation;
 using Shouldly;
-using System;
-using System.Collections;
-using System.Linq;
-using System.Reflection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
 {
@@ -58,7 +52,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
         }
 
         [Fact]
-        public void TargetFrameworks()
+        public void TargetFrameworksWithMultipleValues()
         {
             ProjectCreator.Templates.SdkCsproj(
                     targetFrameworks: new[]
@@ -73,6 +67,36 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
   <PropertyGroup>
     <TargetFrameworks>86A865B7391B4AFBA7466B3882CB21BD;475340B7B92C4E35A9503B747996F5F6;9266B04DA648433F9BB76BBF42474545</TargetFrameworks>
   </PropertyGroup>
+</Project>",
+                    StringCompareShould.IgnoreLineEndings);
+        }
+
+        [Fact]
+        public void TargetFrameworksWithSingleValue()
+        {
+            ProjectCreator.Templates.SdkCsproj(
+                    targetFrameworks: new[]
+                    {
+                        "8A683D24C9CE489C804C79897BC1A44C",
+                    })
+                .Xml
+                .ShouldBe(
+                    $@"<Project Sdk=""{ProjectCreatorConstants.SdkCsprojDefaultSdk}"">
+  <PropertyGroup>
+    <TargetFramework>8A683D24C9CE489C804C79897BC1A44C</TargetFramework>
+  </PropertyGroup>
+</Project>",
+                    StringCompareShould.IgnoreLineEndings);
+        }
+
+        [Fact]
+        public void TargetFrameworksNullDoesNothing()
+        {
+            ProjectCreator.Templates.SdkCsproj(
+                    targetFrameworks: null)
+                .Xml
+                .ShouldBe(
+                    $@"<Project Sdk=""{ProjectCreatorConstants.SdkCsprojDefaultSdk}"">
 </Project>",
                     StringCompareShould.IgnoreLineEndings);
         }

--- a/src/MSBuildProjectCreator/ProjectCreator.Properties.cs
+++ b/src/MSBuildProjectCreator/ProjectCreator.Properties.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// </remarks>
         public ProjectCreator Property(string name, string unevaluatedValue, string condition = null, bool setIfEmpty = false, string label = null)
         {
+            if (unevaluatedValue == null)
+            {
+                return this;
+            }
+
             return Property(LastPropertyGroup, name, unevaluatedValue, condition, setIfEmpty, label);
         }
 

--- a/src/MSBuildProjectCreator/Templates/SdkCsproj.cs
+++ b/src/MSBuildProjectCreator/Templates/SdkCsproj.cs
@@ -5,6 +5,7 @@
 using Microsoft.Build.Evaluation;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Build.Utilities.ProjectCreation
@@ -81,6 +82,8 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             NewProjectFileOptions? projectFileOptions = NewProjectFileOptions.None,
             IDictionary<string, string> globalProperties = null)
         {
+            ICollection<string> targetFrameworkList = targetFrameworks?.ToList();
+
             return SdkCsproj(
                     path: path,
                     sdk: sdk,
@@ -92,7 +95,8 @@ namespace Microsoft.Build.Utilities.ProjectCreation
                     projectCollection: projectCollection,
                     projectFileOptions: projectFileOptions,
                     globalProperties: globalProperties)
-                .Property("TargetFrameworks", targetFrameworks == null ? null : string.Join(";", targetFrameworks))
+                .Property("TargetFramework", targetFrameworkList != null && targetFrameworkList.Count == 1 ? targetFrameworkList.First() : null)
+                .Property("TargetFrameworks", targetFrameworkList != null && targetFrameworkList.Count > 1 ? string.Join(";", targetFrameworkList) : null)
                 .CustomAction(projectCreator);
         }
     }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0",
+  "version": "4.1",
   "assemblyVersion": "1.0",
   "buildNumberOffset": -1,
   "nugetPackageVersion": {


### PR DESCRIPTION
For the SDK-style template a user may or may not know ahead of time how many target frameworks will be used.  Its unsupported to set `TargetFrameworks` to a single value so this change sets `TargetFramework` instead.