### PR TITLE
Fix symbols

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
   <PropertyGroup>
     <DefaultItemExcludes>*log</DefaultItemExcludes>
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,9 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Sdk Name="Microsoft.Build.CentralPackageVersions" />
-
-  <PropertyGroup>
-    <!-- Full symbols so that unit test assertions have more info -->
-    <DebugType Condition=" '$(Configuration)' == 'Debug' ">Full</DebugType>
-  </PropertyGroup>
+<Project>
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.79" />
 </Project>

--- a/global.json
+++ b/global.json
@@ -3,8 +3,5 @@
     "version": "6.0.100-preview",
     "rollForward": "latestMinor",
     "allowPrelease": true
-  },
-  "msbuild-sdks": {
-    "Microsoft.Build.CentralPackageVersions": "2.0.79"
   }
 }


### PR DESCRIPTION
Stop setting DebugType for all projects and instead have unit test projects be set by Shouldly allowing for class libraries to be built with portable PDBs.