### PR TITLE
Fix TryBuild when specifying global properties and target outputs

### DIFF
--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/BuildTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/BuildTests.cs
@@ -17,6 +17,24 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
     public class BuildTests : TestBase
     {
         [Fact]
+        public void BasicBuild()
+        {
+            ProjectCreator
+                .Create(
+                    Path.Combine(TestRootPath, "project1.proj"),
+                    defaultTargets: "Build")
+                .Target("Build")
+                .Target("Restore")
+                .TryBuild("Build", out bool result1)
+                .TryBuild(restore: true, "Build", out bool result2)
+                .TryBuild(restore: true, out bool result3);
+
+            result1.ShouldBeTrue();
+            result2.ShouldBeTrue();
+            result3.ShouldBeTrue();
+        }
+
+        [Fact]
         public void BuildTargetOutputsTest()
         {
             ProjectCreator
@@ -49,7 +67,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
                 .Target("Build")
                 .TaskMessage("Value = $(Property1)", MessageImportance.High)
                 .TryBuild("Build", out bool resultWithoutGlobalProperties, out BuildOutput buildOutputWithoutGlobalProperties)
-                .TryBuild("Build", globalProperties, out bool resultWithGlobalProperties, out BuildOutput buildOutputWithGlobalProperties);
+                .TryBuild("Build", globalProperties, out bool resultWithGlobalProperties, out BuildOutput buildOutputWithGlobalProperties, out IDictionary<string, TargetResult> targetOutputs);
 
             resultWithoutGlobalProperties.ShouldBeTrue();
 

--- a/src/Microsoft.Build.Utilities.ProjectCreation/ProjectCreator.Build.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/ProjectCreator.Build.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
         public ProjectCreator TryBuild(string target, IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
         {
-            return TryBuild(restore: false, target, out result, out buildOutput, out targetOutputs);
+            return TryBuild(restore: false, target, globalProperties, out result, out buildOutput, out targetOutputs);
         }
 
         /// <summary>
@@ -289,7 +289,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <returns>The current <see cref="ProjectCreator"/>.</returns>
         public ProjectCreator TryBuild(bool restore, string target, IDictionary<string, string> globalProperties, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs)
         {
-            return TryBuild(restore, new[] { target }, out result, out buildOutput, out targetOutputs);
+            return TryBuild(restore, new[] { target }, globalProperties, out result, out buildOutput, out targetOutputs);
         }
 
         /// <summary>
@@ -538,7 +538,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         {
             Save();
 
-            globalProperties = globalProperties ?? new Dictionary<string, string>(ProjectCollection.GlobalProperties);
+            globalProperties ??= new Dictionary<string, string>(ProjectCollection.GlobalProperties);
 
             globalProperties["ExcludeRestorePackageImports"] = "true";
             globalProperties["MSBuildRestoreSessionId"] = Guid.NewGuid().ToString("D");
@@ -554,11 +554,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             targetOutputs = buildResult.ResultsByTarget;
 
             result = buildResult.OverallResult == BuildResultCode.Success;
-        }
-
-        private void Restore(out bool result, out IDictionary<string, TargetResult> targetOutputs)
-        {
-            Restore(null, null, out result, out targetOutputs);
         }
     }
 }


### PR DESCRIPTION
Currently when you call TryBuild() and specify global properties and target outputs, the global properties are not passed through.