### PR TITLE
Various fixes to Build actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ The resulting project would look like this:
 ## Building Projects
 Use the `TryBuild` methods to build your projects.  `TryBuild` returns a `BuildOutput` object which captures the build output for you.
 
-This example creates a project that logs a message, executes `TryBuild`, and asserts some conditions against the build output.
+**Note:** Projects are built in a different process to avoid assembly load conflicts so projects must be saved before being built.
+
+This example creates a project that logs a message, saves the project, executes `TryBuild`, and asserts some conditions against the build output.
 ```C#
 ProjectCreator.Create()
     .TaskMessage("Hello, World!")
+    .Save(path)
     .TryBuild(out bool success, out BuildOutput log);
 
 Assert.True(success);

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageFeedTests/PackageFeedTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageFeedTests/PackageFeedTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageFeedTests
         [Fact]
         public void Test1()
         {
-            var targetFrameworks = new[]
+            string[] targetFrameworks = new[]
             {
                 "net45",
                 "net46",

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageRepositoryTests/RepositoryTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageRepositoryTests/RepositoryTests.cs
@@ -27,9 +27,9 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageRepositoryT
                     .Library("netstandard2.0"))
             {
                 ProjectCreator.Templates.SdkCsproj(
+                        path: Path.Combine(TestRootPath, "ClassLibraryA", "ClassLibraryA.csproj"),
                         targetFramework: TargetFramework)
                     .ItemPackageReference(packageA)
-                    .Save(Path.Combine(TestRootPath, "ClassLibraryA", "ClassLibraryA.csproj"))
                     .TryBuild(restore: true, out bool result, out BuildOutput buildOutput);
 
                 result.ShouldBeTrue(buildOutput.GetConsoleLog());

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/TestBase.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/TestBase.cs
@@ -54,5 +54,12 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
         {
             return Path.Combine(TestRootPath, $"{Path.GetRandomFileName()}{extension ?? string.Empty}");
         }
+
+        protected string GetTempProjectPath(string extension = null)
+        {
+            DirectoryInfo tempDirectoryInfo = Directory.CreateDirectory(Path.Combine(TestRootPath, Path.GetRandomFileName()));
+
+            return Path.Combine(tempDirectoryInfo.FullName, $"{Path.GetRandomFileName()}{extension ?? string.Empty}");
+        }
     }
 }

--- a/src/Microsoft.Build.Utilities.ProjectCreation/ExtensionMethods.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/ExtensionMethods.cs
@@ -5,6 +5,7 @@
 using NuGet.LibraryModel;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.Build.Utilities.ProjectCreation
@@ -20,6 +21,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="item">The item to make into an <see cref="IEnumerable{T}"/>.</param>
         /// <returns>The current object as an <see cref="IEnumerable{T}"/>.</returns>
+        [DebuggerStepThrough]
         public static IEnumerable<T> AsEnumerable<T>(this T item)
             where T : class
         {
@@ -40,6 +42,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// </summary>
         /// <param name="libraryIncludeFlags">The <see cref="LibraryIncludeFlags" /> to enumerate.</param>
         /// <returns>Nothing if <paramref name="libraryIncludeFlags" /> is <see cref="LibraryIncludeFlags.None" />, <see cref="LibraryIncludeFlags.All" />, or all flags.</returns>
+        [DebuggerStepThrough]
         public static IEnumerable<LibraryIncludeFlags> EnumerateExcludeFlags(this LibraryIncludeFlags libraryIncludeFlags)
         {
             if (libraryIncludeFlags == LibraryIncludeFlags.All)
@@ -63,6 +66,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// </summary>
         /// <param name="libraryIncludeFlags">The <see cref="LibraryIncludeFlags" /> to enumerate.</param>
         /// <returns>Nothing if <paramref name="libraryIncludeFlags" /> is <see cref="LibraryIncludeFlags.All" />, <see cref="LibraryIncludeFlags.None" />, or all flags.</returns>
+        [DebuggerStepThrough]
         public static IEnumerable<LibraryIncludeFlags> EnumerateIncludeFlags(this LibraryIncludeFlags libraryIncludeFlags)
         {
             if (libraryIncludeFlags == LibraryIncludeFlags.None)
@@ -87,6 +91,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="first">The first dictionary and all of its values to start with.</param>
         /// <param name="second">The second dictionary to merge with the first and override its values.</param>
         /// <returns>A merged <see cref="IDictionary{String,String}"/> with the values of the first dictionary overridden by the second.</returns>
+        [DebuggerStepThrough]
         public static IDictionary<string, string> Merge(this IDictionary<string, string> first, IDictionary<string, string> second)
         {
             return Merge(first, second, StringComparer.OrdinalIgnoreCase);
@@ -99,6 +104,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <param name="second">The second dictionary to merge with the first and override its values.</param>
         /// <param name="comparer">The <see cref="IEqualityComparer{String}"/> implementation to use when comparing keys, or null to use the default <see cref="IEqualityComparer{String}"/> for the type of the key. </param>
         /// <returns>A merged <see cref="IDictionary{String,String}"/> with the values of the first dictionary overridden by the second.</returns>
+        [DebuggerStepThrough]
         public static IDictionary<string, string> Merge(this IDictionary<string, string> first, IDictionary<string, string> second, IEqualityComparer<string> comparer)
         {
             Dictionary<string, string> result = first == null
@@ -119,6 +125,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <param name="item">The item to make into an array.</param>
         /// <returns>An array of T objects.</returns>
+        [DebuggerStepThrough]
         public static T[] ToArrayWithSingleElement<T>(this T item)
             where T : class
         {

--- a/src/Microsoft.Build.Utilities.ProjectCreation/Package.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/Package.cs
@@ -205,8 +205,8 @@ namespace Microsoft.Build.Utilities.ProjectCreation
                 _dependencies[targetFramework] = packageDependencies;
             }
 
-            var includes = new List<string>();
-            var excludes = new List<string>();
+            List<string> includes = new List<string>();
+            List<string> excludes = new List<string>();
 
             LibraryIncludeFlags effectiveInclude = include & ~exclude & ~suppressParent;
 
@@ -299,7 +299,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
 
             using (Stream stream = File.Create(FullPath))
             {
-                foreach (var file in _files.Values)
+                foreach (IPackageFile file in _files.Values)
                 {
                     _packageBuilder.Files.Add(file);
                 }

--- a/src/Microsoft.Build.Utilities.ProjectCreation/ProjectCreator.Project.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/ProjectCreator.Project.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// <summary>
         /// Gets the <see cref="ProjectInstance" /> for the current project.
         /// </summary>
-        public ProjectInstance ProjectInstance => _projectInstance ?? (_projectInstance = Project.CreateProjectInstance());
+        public ProjectInstance ProjectInstance => _projectInstance ??= Project.CreateProjectInstance();
 
         /// <summary>
         /// Gets a <see cref="Project"/> instance from the current project.

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.2",
+  "version": "6.3",
   "assemblyVersion": "1.0",
   "buildNumberOffset": -1,
   "nugetPackageVersion": {


### PR DESCRIPTION
* Use more nodes when building to make builds faster
* Set MSBUILDNOINPROCNODE to ensure all builds happen out-of-proc
* Require projects to be saved before building

Fixes #128 