### PR TITLE
Update NuGet.Frameworks to 6.2.1 for .NET 5+

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MicrosoftBuildPackageVersion>17.2.0</MicrosoftBuildPackageVersion>
     <MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">16.9.0</MicrosoftBuildPackageVersion>
-    <NuGetPackageVersion>6.2.0</NuGetPackageVersion>
+    <NuGetPackageVersion>6.2.1</NuGetPackageVersion>
     <NuGetPackageVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">5.7.1</NuGetPackageVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This change updates the dependency on [NuGet.Frameworks](https://www.nuget.org/packages/NuGet.Frameworks) to 6.2.1 for target frameworks other than `netcoreapp3.1`, which is the latest at this time. This addresses #170 when a new release it published.