### PR TITLE
Cache console output

### DIFF
--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/BuildOutputTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/BuildOutputTests.cs
@@ -37,6 +37,38 @@ FA7FCCBE43B741998BAB399E74F2997D
                     StringCompareShould.IgnoreLineEndings);
         }
 
+        [Fact]
+        public void ConsoleOutputCached()
+        {
+            BuildOutput buildOutput = GetProjectLoggerWithEvents(eventSource =>
+            {
+                eventSource.OnErrorRaised("FDC8FB4F8E084055974580DF7CD7531E", "6496288436BE4E7CAE014F163914063C", "7B07B020E38343A89B3FA844A40895E4", 1, 2, 0, 0);
+                eventSource.OnWarningRaised("E00BBDAEEFAB45949AFEE1BF792B1691", "56206897E63F44159603D22BB7C08145", "C455F26F4D4543E78F109BCB00F02BE2", 1, 2, 0, 0);
+                eventSource.OnMessageRaised("55B991507D52403295E92E4FFA8704F3", MessageImportance.High);
+                eventSource.OnMessageRaised("FA7FCCBE43B741998BAB399E74F2997D");
+                eventSource.OnMessageRaised("67C0E0E52F2A45A981F3143BAF00A4A3", MessageImportance.Low);
+            });
+
+            int callCount = 0;
+
+            buildOutput.ConsoleOutputCreated += (sender, args) => { callCount++; };
+
+            buildOutput.GetConsoleLog();
+            callCount.ShouldBe(1);
+            buildOutput.GetConsoleLog();
+            callCount.ShouldBe(1);
+
+            buildOutput.GetConsoleLog(LoggerVerbosity.Quiet);
+            callCount.ShouldBe(2);
+            buildOutput.GetConsoleLog(LoggerVerbosity.Quiet);
+            callCount.ShouldBe(2);
+
+            buildOutput.GetConsoleLog(LoggerVerbosity.Detailed);
+            callCount.ShouldBe(3);
+            buildOutput.GetConsoleLog(LoggerVerbosity.Detailed);
+            callCount.ShouldBe(3);
+        }
+
         [Theory]
         [InlineData("5F56E5B72FDE4405A021F166D0E4D7A8", "B586E6DA25314DA8B6700CF798A88892")]
         public void Errors(string expectedMessage, string expectedCode)

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/BuildTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/BuildTests.cs
@@ -37,50 +37,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
         }
 
         [Fact]
-        public void BuildTargetOutputsTest()
-        {
-            ProjectCreator
-                .Create(Path.Combine(TestRootPath, "project1.proj"))
-                .Target("Build", returns: "@(MyItems)")
-                .TargetItemInclude("MyItems", "E32099C7AF4E481885B624E5600C718A")
-                .TargetItemInclude("MyItems", "7F38E64414104C6182F492B535926187")
-                .Save()
-                .TryBuild("Build", out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs);
-
-            result.ShouldBeTrue(buildOutput.GetConsoleLog());
-
-            KeyValuePair<string, TargetResult> item = targetOutputs.ShouldHaveSingleItem(buildOutput.GetConsoleLog());
-
-            item.Key.ShouldBe("Build", buildOutput.GetConsoleLog());
-
-            item.Value.Items.Select(i => i.ItemSpec).ShouldBe(new[] { "E32099C7AF4E481885B624E5600C718A", "7F38E64414104C6182F492B535926187" }, buildOutput.GetConsoleLog());
-        }
-
-        [Fact]
-        public void BuildWithGlobalProperties()
-        {
-            Dictionary<string, string> globalProperties = new Dictionary<string, string>
-            {
-                ["Property1"] = "D7BBABDFB2D142D3A75E0C1A33E33780",
-            };
-
-            ProjectCreator
-                .Create(Path.Combine(TestRootPath, "project1.proj"))
-                .Target("Build")
-                .TaskMessage("Value = $(Property1)", MessageImportance.High)
-                .TryBuild("Build", out bool resultWithoutGlobalProperties, out BuildOutput buildOutputWithoutGlobalProperties)
-                .TryBuild("Build", globalProperties, out bool resultWithGlobalProperties, out BuildOutput buildOutputWithGlobalProperties, out IDictionary<string, TargetResult> targetOutputs);
-
-            resultWithoutGlobalProperties.ShouldBeTrue(buildOutputWithoutGlobalProperties.GetConsoleLog());
-
-            buildOutputWithoutGlobalProperties.MessageEvents.High.ShouldHaveSingleItem(buildOutputWithoutGlobalProperties.GetConsoleLog()).Message.ShouldBe("Value = ", buildOutputWithoutGlobalProperties.GetConsoleLog());
-
-            resultWithGlobalProperties.ShouldBeTrue(buildOutputWithGlobalProperties.GetConsoleLog());
-
-            buildOutputWithGlobalProperties.MessageEvents.High.ShouldHaveSingleItem(buildOutputWithGlobalProperties.GetConsoleLog()).Message.ShouldBe("Value = D7BBABDFB2D142D3A75E0C1A33E33780", buildOutputWithGlobalProperties.GetConsoleLog());
-        }
-
-        [Fact]
         public void BuildOutputContainsOutOfProcMessages()
         {
             const int messageCount = 100;
@@ -131,6 +87,50 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
             buildOutput.IsShutdown.ShouldBeTrue();
 
             buildOutput.MessageEvents.High.Count.ShouldBeGreaterThanOrEqualTo(100, buildOutput.GetConsoleLog());
+        }
+
+        [Fact]
+        public void BuildTargetOutputsTest()
+        {
+            ProjectCreator
+                .Create(Path.Combine(TestRootPath, "project1.proj"))
+                .Target("Build", returns: "@(MyItems)")
+                .TargetItemInclude("MyItems", "E32099C7AF4E481885B624E5600C718A")
+                .TargetItemInclude("MyItems", "7F38E64414104C6182F492B535926187")
+                .Save()
+                .TryBuild("Build", out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+
+            KeyValuePair<string, TargetResult> item = targetOutputs.ShouldHaveSingleItem(buildOutput.GetConsoleLog());
+
+            item.Key.ShouldBe("Build", buildOutput.GetConsoleLog());
+
+            item.Value.Items.Select(i => i.ItemSpec).ShouldBe(new[] { "E32099C7AF4E481885B624E5600C718A", "7F38E64414104C6182F492B535926187" }, buildOutput.GetConsoleLog());
+        }
+
+        [Fact]
+        public void BuildWithGlobalProperties()
+        {
+            Dictionary<string, string> globalProperties = new Dictionary<string, string>
+            {
+                ["Property1"] = "D7BBABDFB2D142D3A75E0C1A33E33780",
+            };
+
+            ProjectCreator
+                .Create(Path.Combine(TestRootPath, "project1.proj"))
+                .Target("Build")
+                .TaskMessage("Value = $(Property1)", MessageImportance.High)
+                .TryBuild("Build", out bool resultWithoutGlobalProperties, out BuildOutput buildOutputWithoutGlobalProperties)
+                .TryBuild("Build", globalProperties, out bool resultWithGlobalProperties, out BuildOutput buildOutputWithGlobalProperties, out IDictionary<string, TargetResult> targetOutputs);
+
+            resultWithoutGlobalProperties.ShouldBeTrue(buildOutputWithoutGlobalProperties.GetConsoleLog());
+
+            buildOutputWithoutGlobalProperties.MessageEvents.High.ShouldHaveSingleItem(buildOutputWithoutGlobalProperties.GetConsoleLog()).Message.ShouldBe("Value = ", buildOutputWithoutGlobalProperties.GetConsoleLog());
+
+            resultWithGlobalProperties.ShouldBeTrue(buildOutputWithGlobalProperties.GetConsoleLog());
+
+            buildOutputWithGlobalProperties.MessageEvents.High.ShouldHaveSingleItem(buildOutputWithGlobalProperties.GetConsoleLog()).Message.ShouldBe("Value = D7BBABDFB2D142D3A75E0C1A33E33780", buildOutputWithGlobalProperties.GetConsoleLog());
         }
 
         [Fact]
@@ -185,23 +185,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
             buildOutput.MessageEvents.High.ShouldContain(i => i.Message == "Restoring...", buildOutput.GetConsoleLog());
 
             buildOutput.MessageEvents.High.ShouldContain(i => i.Message == "Building...", buildOutput.GetConsoleLog());
-        }
-
-        [Fact]
-        public void ProjectWithGlobalPropertiesUsedDuringBuild()
-        {
-            ProjectCollection projectCollection = new ProjectCollection(new Dictionary<string, string>
-            {
-                ["Property1"] = "F6EBAC88A10E453B9AF8FA656A574737",
-            });
-
-            ProjectCreator creator = ProjectCreator.Create(projectCollection: projectCollection)
-                .TaskMessage("$(Property1)", MessageImportance.High)
-                .TryBuild(out bool result, out BuildOutput buildOutput);
-
-            result.ShouldBeTrue(buildOutput.GetConsoleLog());
-
-            buildOutput.Messages.Last().ShouldBe("F6EBAC88A10E453B9AF8FA656A574737");
         }
 
         [Fact]
@@ -289,6 +272,23 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
 
             fileLogContents.ShouldContain("38EC33B686134B3C8DE4B8E571D4FB24", Case.Sensitive, fileLogContents);
             fileLogContents.ShouldContain("B7F9A257198D4A44A06BB6146AB27440", Case.Sensitive, fileLogContents);
+        }
+
+        [Fact]
+        public void ProjectWithGlobalPropertiesUsedDuringBuild()
+        {
+            ProjectCollection projectCollection = new ProjectCollection(new Dictionary<string, string>
+            {
+                ["Property1"] = "F6EBAC88A10E453B9AF8FA656A574737",
+            });
+
+            ProjectCreator creator = ProjectCreator.Create(projectCollection: projectCollection)
+                .TaskMessage("$(Property1)", MessageImportance.High)
+                .TryBuild(out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+
+            buildOutput.Messages.Last().ShouldBe("F6EBAC88A10E453B9AF8FA656A574737");
         }
 
         [Fact]

--- a/src/Microsoft.Build.Utilities.ProjectCreation/BuildEventArgsCollection.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/BuildEventArgsCollection.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation
     /// </summary>
     public abstract class BuildEventArgsCollection : IDisposable
     {
-        internal event EventHandler<LoggerVerbosity>? ConsoleOutputCreated;
-
         /// <summary>
         /// Stores all build events.
         /// </summary>
@@ -39,8 +37,14 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         /// </summary>
         private readonly List<BuildWarningEventArgs> _warningEvents = new List<BuildWarningEventArgs>();
 
+        /// <summary>
+        /// Stores the last console output.
+        /// </summary>
         private string? _lastConsoleOutput = null;
 
+        /// <summary>
+        ///  Stores the <see cref="LoggerVerbosity" /> of the last console output.
+        /// </summary>
         private LoggerVerbosity _lastVerbosity = LoggerVerbosity.Normal;
 
         /// <summary>
@@ -51,6 +55,11 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             MessageEvents = new BuildMessageEventArgsCollection(_messageEvents);
             Messages = new BuildMessageCollection(this);
         }
+
+        /// <summary>
+        /// Occurs when console output is created and the cache is not used.
+        /// </summary>
+        internal event EventHandler<LoggerVerbosity>? ConsoleOutputCreated;
 
         /// <summary>
         /// Gets all events that were logged.


### PR DESCRIPTION
As long as the verbosity is the same and no events were added, then return the last console output instead of recreating it for every call.