### PR TITLE
Reset ProjectInstance after build

### DIFF
--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/BuildTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/BuildTests.cs
@@ -188,6 +188,22 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
         }
 
         [Fact]
+        public void CanRestoreAndBuildMultipleTimes()
+        {
+            ProjectCreator projectCreator = ProjectCreator.Templates.SdkCsproj(
+                path: GetTempFileName(".csproj"),
+                targetFramework: TargetFramework)
+                .Save()
+                .TryBuild(restore: true, "Build", out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+
+            projectCreator.TryBuild(out result, out buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+        }
+
+        [Fact]
         public void ProjectCollectionLoggersWork()
         {
             string binLogPath = Path.Combine(TestRootPath, "test.binlog");

--- a/src/Microsoft.Build.Utilities.ProjectCreation/ProjectCreator.Build.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/ProjectCreator.Build.cs
@@ -535,6 +535,8 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             {
                 targetOutputs = buildResult.ResultsByTarget;
             }
+
+            ResetProjectInstance();
         }
 
         private void Restore(IDictionary<string, string>? globalProperties, BuildOutput buildOutput, out bool result, out IDictionary<string, TargetResult> targetOutputs)

--- a/src/Microsoft.Build.Utilities.ProjectCreation/ProjectCreator.Project.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/ProjectCreator.Project.cs
@@ -126,5 +126,10 @@ namespace Microsoft.Build.Utilities.ProjectCreation
 
             return this;
         }
+
+        internal void ResetProjectInstance()
+        {
+            _projectInstance = null;
+        }
     }
 }


### PR DESCRIPTION
Fixes #254

The `ProjectInstance` is cached and reused for subsequent builds but that causes build errors.  This change resets the ProjectInstance after a build so a new one can be fetched for the next build.