### PR TITLE
Convert bools to lowercase for XML spec compliance

### DIFF
--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageFeedTests/PackageFeedFileTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageFeedTests/PackageFeedFileTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageFeedTests
             GetFileContents(packageA.FullPath, relativePath)
                 .ShouldBe("585B55DD5AC54A10B841B3D9A00129D8");
 
-            GetNuspec(packageA)
+            GetNuspecReader(packageA)
                 .DependencyGroups.Select(i => i.TargetFramework).ToList()
                 .ShouldContain("net46");
         }
@@ -105,7 +105,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageFeedTests
             GetFileContents(packageA.FullPath, relativePath)
                 .ShouldBe("607779BADE3645F8A288543213BFE948");
 
-            GetNuspec(packageA)
+            GetNuspecReader(packageA)
                 .DependencyGroups
                 .ShouldBeEmpty();
         }
@@ -126,7 +126,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageFeedTests
 
             GetFileContents(package.FullPath, Path.Combine("contentFiles", expectedLanguage, expectedTargetFramework, relativePath)).ShouldBe(expectedContents);
 
-            NuspecReader nuspecReader = GetNuspec(package);
+            NuspecReader nuspecReader = GetNuspecReader(package);
 
             PackageContentFileEntry file = nuspecReader.ContentFiles.ShouldHaveSingleItem();
 

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageFeedTests/PackageFeedTestBase.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageFeedTests/PackageFeedTestBase.cs
@@ -59,11 +59,16 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageFeedTests
             });
         }
 
-        protected NuspecReader GetNuspec(Package package)
+        protected string GetNuspec(Package package)
         {
             package.FullPath.ShouldNotBeNull();
 
-            return new NuspecReader(GetFileContents(package.FullPath, filePath => filePath.EndsWith($"{package.Id}.nuspec", StringComparison.OrdinalIgnoreCase)));
+            return GetFileContents(package.FullPath, filePath => filePath.EndsWith($"{package.Id}.nuspec", StringComparison.OrdinalIgnoreCase));
+        }
+
+        protected NuspecReader GetNuspecReader(Package package)
+        {
+            return new NuspecReader(GetNuspec(package));
         }
 
         protected Assembly? LoadAssembly(string packageFullPath, string filePath)

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageFeedTests/PackageFeedTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageFeedTests/PackageFeedTests.cs
@@ -56,8 +56,9 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageFeedTests
 
             package.ShouldNotBeNull();
 
+            char sep = Path.DirectorySeparatorChar;
             GetNuspec(package).ShouldBe(
-@"<package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+$@"<package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
   <metadata minClientVersion=""2.12"">
     <id>PackageD</id>
     <version>1.2.3-beta</version>
@@ -71,10 +72,11 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageFeedTests
       <group targetFramework=""any"" />
     </dependencies>
     <contentFiles>
-      <files include=""any\net45\file.txt"" copyToOutput=""true"" flatten=""false"" buildAction=""None"" />
+      <files include=""any{sep}net45{sep}file.txt"" copyToOutput=""true"" flatten=""false"" buildAction=""None"" />
     </contentFiles>
   </metadata>
-</package>");
+</package>",
+StringCompareShould.IgnoreLineEndings);
         }
 
         [Fact]

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageFeedTests/PackageFeedTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageFeedTests/PackageFeedTests.cs
@@ -63,15 +63,15 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageFeedTests
     <version>1.2.3-beta</version>
     <authors>Author</authors>
     <description>Description</description>
-    <requireLicenseAcceptance>False</requireLicenseAcceptance>
-    <developmentDependency>False</developmentDependency>
-    <serviceable>False</serviceable>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <developmentDependency>false</developmentDependency>
+    <serviceable>false</serviceable>
     <dependencies>
       <group targetFramework=""net45"" />
       <group targetFramework=""any"" />
     </dependencies>
     <contentFiles>
-      <files include=""any\net45\file.txt"" copyToOutput=""True"" flatten=""False"" buildAction=""None"" />
+      <files include=""any\net45\file.txt"" copyToOutput=""true"" flatten=""false"" buildAction=""None"" />
     </contentFiles>
   </metadata>
 </package>");

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageFeedTests/PackageFeedTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageFeedTests/PackageFeedTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 
 using Shouldly;
-using System;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -28,7 +27,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageFeedTests
             packageA.Id.ShouldBe("PackageA");
             packageA.Version.ShouldBe("1.0.0");
 
-            NuspecReader nuspec = GetNuspec(packageA);
+            NuspecReader nuspec = GetNuspecReader(packageA);
 
             nuspec.Authors.ShouldBe("John Smith");
             nuspec.Description.ShouldBe("Custom Description");
@@ -40,6 +39,42 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageFeedTests
             targetFramework.ShouldBe("net45");
 
             dependencies.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void NuspecXmlSerializesCorrectly()
+        {
+            using PackageFeed packageFeed = PackageFeed.Create(FeedRootPath)
+                .Package(
+                    id: "PackageD",
+                    version: "1.2.3-beta",
+                    out Package package,
+                    developmentDependency: false)
+                    .Library("net45")
+                    .ContentFileText("file.txt", "584717ec-6132-4418-853c-1fa72778f52a", "net45", "None", copyToOutput: true, flatten: false)
+                .Save();
+
+            package.ShouldNotBeNull();
+
+            GetNuspec(package).ShouldBe(
+@"<package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+  <metadata minClientVersion=""2.12"">
+    <id>PackageD</id>
+    <version>1.2.3-beta</version>
+    <authors>Author</authors>
+    <description>Description</description>
+    <requireLicenseAcceptance>False</requireLicenseAcceptance>
+    <developmentDependency>False</developmentDependency>
+    <serviceable>False</serviceable>
+    <dependencies>
+      <group targetFramework=""net45"" />
+      <group targetFramework=""any"" />
+    </dependencies>
+    <contentFiles>
+      <files include=""any\net45\file.txt"" copyToOutput=""True"" flatten=""False"" buildAction=""None"" />
+    </contentFiles>
+  </metadata>
+</package>");
         }
 
         [Fact]
@@ -59,7 +94,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageFeedTests
             packageA.Id.ShouldBe("PackageA");
             packageA.Version.ShouldBe("1.0.0");
 
-            NuspecReader nuspec = GetNuspec(packageA);
+            NuspecReader nuspec = GetNuspecReader(packageA);
 
             nuspec.Authors.ShouldBe("John Smith");
             nuspec.Description.ShouldBe("Custom Description");

--- a/src/Microsoft.Build.Utilities.ProjectCreation/ExtensionMethods.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/ExtensionMethods.cs
@@ -118,11 +118,27 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             }
         }
 
+        internal static void WriteAttributeStringIfNotNull(this XmlWriter writer, string localName, bool? value)
+        {
+            if (value.HasValue)
+            {
+                writer.WriteAttributeString(localName, value.Value ? "true" : "false");
+            }
+        }
+
         internal static void WriteElementStringIfNotNull(this XmlWriter writer, string localName, string? value)
         {
             if (!string.IsNullOrWhiteSpace(value))
             {
                 writer.WriteElementString(localName, value);
+            }
+        }
+
+        internal static void WriteElementStringIfNotNull(this XmlWriter writer, string localName, bool? value)
+        {
+            if (value.HasValue)
+            {
+                writer.WriteElementString(localName, value.Value ? "true" : "false");
             }
         }
     }

--- a/src/Microsoft.Build.Utilities.ProjectCreation/Package.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/Package.cs
@@ -462,18 +462,18 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             writer.WriteElementStringIfNotNull("copyright", Copyright);
             writer.WriteElementStringIfNotNull("tags", Tags);
             writer.WriteElementStringIfNotNull("projectUrl", ProjectUrl);
-            writer.WriteElementStringIfNotNull("requireLicenseAcceptance", RequireLicenseAcceptance.ToString().ToLowerInvariant());
+            writer.WriteElementStringIfNotNull("requireLicenseAcceptance", RequireLicenseAcceptance);
             writer.WriteElementStringIfNotNull("licenseUrl", LicenseUrl);
             writer.WriteElementStringIfNotNull("icon", Icon);
             writer.WriteElementStringIfNotNull("iconUrl", IconUrl);
-            writer.WriteElementStringIfNotNull("developmentDependency", DevelopmentDependency.ToString().ToLowerInvariant());
+            writer.WriteElementStringIfNotNull("developmentDependency", DevelopmentDependency);
             writer.WriteElementStringIfNotNull("language", Language);
             writer.WriteElementStringIfNotNull("title", Title);
             writer.WriteElementStringIfNotNull("tags", Tags);
             writer.WriteElementStringIfNotNull("summary", Summary);
             writer.WriteElementStringIfNotNull("owners", Owners);
             writer.WriteElementStringIfNotNull("releaseNotes", ReleaseNotes);
-            writer.WriteElementStringIfNotNull("serviceable", Serviceable.ToString().ToLowerInvariant());
+            writer.WriteElementStringIfNotNull("serviceable", Serviceable);
 
             if (PackageTypes != null && PackageTypes.Any())
             {
@@ -544,8 +544,8 @@ namespace Microsoft.Build.Utilities.ProjectCreation
                     writer.WriteStartElement("files");
                     writer.WriteAttributeStringIfNotNull("include", contentFilesEntry.Include);
                     writer.WriteAttributeStringIfNotNull("exclude", contentFilesEntry.Exclude);
-                    writer.WriteAttributeStringIfNotNull("copyToOutput", contentFilesEntry.CopyToOutput.ToString()?.ToLowerInvariant());
-                    writer.WriteAttributeStringIfNotNull("flatten", contentFilesEntry.Flatten.ToString()?.ToLowerInvariant());
+                    writer.WriteAttributeStringIfNotNull("copyToOutput", contentFilesEntry.CopyToOutput);
+                    writer.WriteAttributeStringIfNotNull("flatten", contentFilesEntry.Flatten);
                     writer.WriteAttributeStringIfNotNull("buildAction", contentFilesEntry.BuildAction);
                     writer.WriteEndElement();
                 }

--- a/src/Microsoft.Build.Utilities.ProjectCreation/Package.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/Package.cs
@@ -462,18 +462,18 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             writer.WriteElementStringIfNotNull("copyright", Copyright);
             writer.WriteElementStringIfNotNull("tags", Tags);
             writer.WriteElementStringIfNotNull("projectUrl", ProjectUrl);
-            writer.WriteElementStringIfNotNull("requireLicenseAcceptance", RequireLicenseAcceptance.ToString());
+            writer.WriteElementStringIfNotNull("requireLicenseAcceptance", RequireLicenseAcceptance.ToString().ToLowerInvariant());
             writer.WriteElementStringIfNotNull("licenseUrl", LicenseUrl);
             writer.WriteElementStringIfNotNull("icon", Icon);
             writer.WriteElementStringIfNotNull("iconUrl", IconUrl);
-            writer.WriteElementStringIfNotNull("developmentDependency", DevelopmentDependency.ToString());
+            writer.WriteElementStringIfNotNull("developmentDependency", DevelopmentDependency.ToString().ToLowerInvariant());
             writer.WriteElementStringIfNotNull("language", Language);
             writer.WriteElementStringIfNotNull("title", Title);
             writer.WriteElementStringIfNotNull("tags", Tags);
             writer.WriteElementStringIfNotNull("summary", Summary);
             writer.WriteElementStringIfNotNull("owners", Owners);
             writer.WriteElementStringIfNotNull("releaseNotes", ReleaseNotes);
-            writer.WriteElementStringIfNotNull("serviceable", Serviceable.ToString());
+            writer.WriteElementStringIfNotNull("serviceable", Serviceable.ToString().ToLowerInvariant());
 
             if (PackageTypes != null && PackageTypes.Any())
             {
@@ -544,8 +544,8 @@ namespace Microsoft.Build.Utilities.ProjectCreation
                     writer.WriteStartElement("files");
                     writer.WriteAttributeStringIfNotNull("include", contentFilesEntry.Include);
                     writer.WriteAttributeStringIfNotNull("exclude", contentFilesEntry.Exclude);
-                    writer.WriteAttributeString("copyToOutput", contentFilesEntry.CopyToOutput.ToString());
-                    writer.WriteAttributeStringIfNotNull("flatten", contentFilesEntry.Flatten.ToString());
+                    writer.WriteAttributeStringIfNotNull("copyToOutput", contentFilesEntry.CopyToOutput.ToString()?.ToLowerInvariant());
+                    writer.WriteAttributeStringIfNotNull("flatten", contentFilesEntry.Flatten.ToString()?.ToLowerInvariant());
                     writer.WriteAttributeStringIfNotNull("buildAction", contentFilesEntry.BuildAction);
                     writer.WriteEndElement();
                 }


### PR DESCRIPTION
`bool.ToString()` returns an uppercase "True" or "False", but XML is
case sensitive and specifies that bools should be lowercase (see
https://learn.microsoft.com/en-us/dotnet/api/system.boolean.tostring).

While the built-in NuspecReader handles this, tools like NuGet Package
Explorer do not. Update `Package.WriteNuspec` to emit lowercase
bools.

I also added a basic unit test to catch accidental regressions.
