### PR TITLE
Remove nullable annotation from NuspecReader PackageTypes

### DIFF
--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/NuspecReader.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/NuspecReader.cs
@@ -68,13 +68,18 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
 
         public string? Owners => GetElement("owners");
 
-        public IEnumerable<string?> PackageTypes
+        public IEnumerable<string> PackageTypes
         {
             get
             {
                 foreach (XElement group in _document.XPathSelectElements("//ns:package/ns:metadata/ns:packageTypes/ns:packageType", _namespaceManager))
                 {
-                    yield return group.Attribute("name")?.Value;
+                    XAttribute? type = group.Attribute("name");
+
+                    if (type != null)
+                    {
+                        yield return type.Value;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Previously, `PackageTypes` on the NuspecReader allowed returning null strings from the enumerable.

This type causes an issue when passing the result of the NuspecReader (which is `IEnumerable<string?>`) as the input of the `Package` (which is `IEnumerable<string>?`). Since a valid .nuspec's `<packageType>` will always have a `name` (according to https://github.com/NuGet/Home/wiki/Package-Type-%5BPacking%5D), update the enumerable to only return non-null values.