### PR TITLE
Add LicenseUrl and LicenseExpression to NuspecReader

### DIFF
--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/NuspecReader.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/NuspecReader.cs
@@ -62,7 +62,24 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
 
         public string? License => GetElement("license");
 
+        public string? LicenseExpression
+        {
+            get
+            {
+                string? licenseType = LicenseType;
+
+                if (licenseType != null && licenseType.Equals("expression", StringComparison.OrdinalIgnoreCase))
+                {
+                    return License;
+                }
+
+                return null;
+            }
+        }
+
         public string? LicenseType => GetAttribute("license", "type");
+
+        public string? LicenseUrl => GetElement("licenseUrl");
 
         public string? LicenseVersion => GetAttribute("license", "version");
 

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/NuspecReaderTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/NuspecReaderTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Jeff Kluge. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
+{
+    public class NuspecReaderTests
+    {
+        [Fact]
+        public void LicenseExpressionIsNullForFileLicenses()
+        {
+            string contents =
+@"<package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+  <metadata>
+    <id>PackageL</id>
+    <version>16.4.60</version>
+    <authors>UserA</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type=""file"">LICENSE</license>
+    <packageTypes>
+      <packageType name=""Dependency"" />
+    </packageTypes>
+  </metadata>
+</package>";
+
+            NuspecReader nuspec = new NuspecReader(contents);
+
+            nuspec.License.ShouldBe("LICENSE");
+            nuspec.LicenseExpression.ShouldBeNull();
+            nuspec.LicenseType.ShouldBe("file");
+            nuspec.LicenseVersion.ShouldBeNull();
+            nuspec.LicenseUrl.ShouldBeNull();
+        }
+    }
+}

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageRepositoryTests/RepositoryTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/PackageRepositoryTests/RepositoryTests.cs
@@ -113,16 +113,17 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageRepositoryT
                     copyright: "Copyright 2000",
                     developmentDependency: true,
                     icon: Path.Combine("some", "icon.jpg"),
-                    iconUrl: "https://icon.url",
+                    iconUrl: "https://icon.invalid/url",
                     language: "Pig latin",
+                    licenseUrl: "https://license.invalid/url",
                     licenseExpression: "MIT",
                     licenseVersion: "1.0.0",
                     owners: "Owner1;Owner2",
                     packageTypes: new List<string> { "Dependency", "DotnetCliTool" },
-                    projectUrl: "https://project.url",
+                    projectUrl: "https://project.invalid/url",
                     releaseNotes: "Release notes for PackageD",
                     repositoryType: "Git",
-                    repositoryUrl: "https://repository.url",
+                    repositoryUrl: "https://repository.invalid/url",
                     repositoryBranch: "Branch1000",
                     repositoryCommit: "Commit14",
                     requireLicenseAcceptance: true,
@@ -145,25 +146,53 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests.PackageRepositoryT
                 nuspec.Description.ShouldBe("Custom description");
                 nuspec.DevelopmentDependency.ShouldBeTrue();
                 nuspec.Icon.ShouldBe(Path.Combine("some", "icon.jpg"));
-                nuspec.IconUrl.ShouldBe("https://icon.url");
+                nuspec.IconUrl.ShouldBe("https://icon.invalid/url");
                 nuspec.Id.ShouldBe("PackageD");
                 nuspec.Language.ShouldBe("Pig latin");
                 nuspec.License.ShouldBe("MIT");
+                nuspec.LicenseExpression.ShouldBe("MIT");
                 nuspec.LicenseType.ShouldBe("expression");
+                nuspec.LicenseUrl.ShouldBe("https://license.invalid/url");
                 nuspec.LicenseVersion.ShouldBe("1.0.0");
                 nuspec.Owners.ShouldBe("Owner1;Owner2");
                 nuspec.PackageTypes.ShouldBe(new[] { "Dependency", "DotnetCliTool" });
-                nuspec.ProjectUrl.ShouldBe("https://project.url");
+                nuspec.ProjectUrl.ShouldBe("https://project.invalid/url");
                 nuspec.ReleaseNotes.ShouldBe("Release notes for PackageD");
                 nuspec.RepositoryBranch.ShouldBe("Branch1000");
                 nuspec.RepositoryCommit.ShouldBe("Commit14");
                 nuspec.RepositoryType.ShouldBe("Git");
-                nuspec.RepositoryUrl.ShouldBe("https://repository.url");
+                nuspec.RepositoryUrl.ShouldBe("https://repository.invalid/url");
                 nuspec.RequireLicenseAcceptance.ShouldBeTrue();
                 nuspec.Serviceable.ShouldBeTrue();
                 nuspec.Summary.ShouldBe("Summary of PackageD");
                 nuspec.Tags.ShouldBe("Tag1 Tag2 Tag3");
                 nuspec.Title.ShouldBe("Title of PackageD");
+            }
+        }
+
+        [Fact]
+        public void LicenseExpressionPackagePropertiesCanBeNull()
+        {
+            using (PackageRepository packageRepository = PackageRepository.Create(TestRootPath)
+                .Package(
+                    id: "PackageD",
+                    version: "1.2.3",
+                    out Package package,
+                    licenseUrl: "https://license.invalid/url",
+                    licenseExpression: null,
+                    licenseVersion: null))
+            {
+                package.ShouldNotBeNull();
+
+                FileInfo nuspecFileInfo = new FileInfo(packageRepository.GetManifestFilePath(package.Id, package.Version)).ShouldExist();
+
+                NuspecReader nuspec = new NuspecReader(nuspecFileInfo);
+
+                nuspec.License.ShouldBeNull();
+                nuspec.LicenseExpression.ShouldBeNull();
+                nuspec.LicenseType.ShouldBeNull();
+                nuspec.LicenseUrl.ShouldBe("https://license.invalid/url");
+                nuspec.LicenseVersion.ShouldBeNull();
             }
         }
 


### PR DESCRIPTION
Add two new properties to NuspecReader:

1. `LicenseUrl`
2. `LicenseExpression`

## LicenseUrl

Maps to the `<licenseUrl>` element, which can be set by the `Package`, but could never be read. Also update unit tests to validate values.

Note that as part of this PR I changed the domains for the sample URLs to use the TLD `.invalid`. While it _really_ doesn't matter, using the .invalid TLD (reserved in [RFC2606](https://www.rfc-editor.org/rfc/rfc2606.txt)) is ever-so-slightly more correct, and avoids the possibility of accidentally trying to resolve these fake domains in the future.

## LicenseExpression

A helper that returns the value of `<license>` _if_ the license type is "expression". This centralizes what is otherwise a slightly gnarly ternary expression to disambiguate license expressions from license files:

```csharp
string? licenseExpression = reader.LicenseType?.Equals("expression", StringComparison.OrdinalIgnoreCase) ?? false ? reader.License : null
```

 The `Package` class currently _can't_ create packages with a `<license type="file">`. This addition is a preparatory refactoring for an upcoming change to move the NuspecReader as an internal member of the main library.

Also added a unit test.