### PR TITLE
Move MSBuild initialization from MSBuildTestBase to MSBuildAssemblyResolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,20 @@ The above extension method would add the following item:
   </MyCustomType>
 </ItemGroup>
 ```
+
 ## Resolving MSBuild
-This API does not redistribute MSBuild and so it must be located at run-time.  There are three ways to do this:
+
+This API does not redistribute MSBuild and so it must be located at run-time. There are two locators to be aware of:
+
+1. `MSBuildAssemblyResolver.Register()` provided in this package
+2. `MSBuildLocator.RegisterDefaults()` in the [MSBuildLocator](https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application?view=vs-2019#use-microsoftbuildlocator) package
+
+In either case, you need to register before running any MSBuild operations. There are three main ways to ensure registration:
 
 ### 1. Module initializer (preferred)
 
-If you're targeting C# 9.0+ / .NET 5+, use a [module initializer](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/module-initializers)
-to call `MSBuildAssemblyResolver.Register()`. MSBuild assemblies will be automatically located when your assembly is loaded.
+If you're targeting C# 9.0+ / .NET 5+, use a [module initializer](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/module-initializers).
+MSBuild assemblies will be automatically located when your assembly is loaded:
 
 ```C#
 using System.Runtime.CompilerServices;
@@ -115,7 +122,7 @@ internal static class MyModuleInitializer
 ### 2. Inherit from MSBuildTestBase
 
 If you're unable or don't want to use a module initializer and your project is a unit test, have your test class inherit
-from [MSBuildTestBase](https://github.com/jeffkl/MSBuildProjectCreator/blob/main/src/MSBuildProjectCreator/MSBuildTestBase.cs).
+from [MSBuildTestBase](https://github.com/jeffkl/MSBuildProjectCreator/blob/main/src/MSBuildProjectCreator/MSBuildTestBase.cs):
 
 ```C#
 /// <summary>
@@ -134,17 +141,16 @@ public class MyTest : MyTestBase
 }
 ```
 
-### 3. Use MSBuildLocator
+### 3. Use a static constructor
 
-Use [MSBuildLocator](https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application?view=vs-2019#use-microsoftbuildlocator)
-to register an instance of MSBuild.
+Add a static constructor and call the registration API:
 
 ```C#
 public static class MyApp
 {
     public static MyApp()
     {
-        MSBuildLocator.RegisterDefaults();
+        MSBuildAssemblyResolver.Register();
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -94,7 +94,29 @@ The above extension method would add the following item:
 ## Resolving MSBuild
 This API does not redistribute MSBuild and so it must be located at run-time.  There are three ways to do this:
 
-1. If your project is a unit test, have your test class inherit from [MSBuildTestBase](https://github.com/jeffkl/MSBuildProjectCreator/blob/main/src/MSBuildProjectCreator/MSBuildTestBase.cs)
+### 1. Module initializer (preferred)
+
+If you're targeting C# 9.0+ / .NET 5+, use a [module initializer](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/module-initializers)
+to call `MSBuildAssemblyResolver.Register()`. MSBuild assemblies will be automatically located when your assembly is loaded.
+
+```C#
+using System.Runtime.CompilerServices;
+
+internal static class MyModuleInitializer
+{
+    [ModuleInitializer]
+    internal static void InitializeMSBuild()
+    {
+        MSBuildAssemblyResolver.Register();
+    }
+}
+```
+
+### 2. Inherit from MSBuildTestBase
+
+If you're unable or don't want to use a module initializer and your project is a unit test, have your test class inherit
+from [MSBuildTestBase](https://github.com/jeffkl/MSBuildProjectCreator/blob/main/src/MSBuildProjectCreator/MSBuildTestBase.cs).
+
 ```C#
 /// <summary>
 /// A base class for all unit tests that inherits from MSBuildTestBase.
@@ -111,18 +133,12 @@ public class MyTest : MyTestBase
 {
 }
 ```
-2. Attach the [assembly resolve event handler](https://docs.microsoft.com/en-us/dotnet/standard/assembly/resolve-loads) to [MSBuildAssemblyResolver.AssemblyResolve](https://github.com/jeffkl/MSBuildProjectCreator/blob/main/src/MSBuildProjectCreator/MSBuildAssemblyResolver.cs)
 
-``` C#
-public static class MyApp
-{
-    public static MyApp()
-    {
-        AppDomain.CurrentDomain.AssemblyResolve += MSBuildAssemblyResolver.AssemblyResolve;
-    }
-}
-```
-3. Use [MSBuildLocator](https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application?view=vs-2019#use-microsoftbuildlocator) to register an instance of MSBuild.
+### 3. Use MSBuildLocator
+
+Use [MSBuildLocator](https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application?view=vs-2019#use-microsoftbuildlocator)
+to register an instance of MSBuild.
+
 ```C#
 public static class MyApp
 {

--- a/src/Microsoft.Build.Utilities.ProjectCreation/MSBuildTestBase.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/MSBuildTestBase.cs
@@ -2,30 +2,20 @@
 //
 // Licensed under the MIT license.
 
-using System;
-using System.IO;
-#if NET6_0_OR_GREATER
-using System.Runtime.Loader;
-#endif
-
 namespace Microsoft.Build.Utilities.ProjectCreation
 {
     /// <summary>
-    /// Provides a base class for unit test classes that use MSBuild.  This class resolves MSBuild related assemblies automatically.
+    /// Provides a base class for unit test classes that use MSBuild. This class resolves MSBuild related assemblies automatically.
     /// </summary>
+    /// <remarks>
+    /// Prefer calling <see cref="MSBuildAssemblyResolver.Register"/> from a <c>ModuleInitalizerAttribute</c> if your target framework
+    /// supports one. This base class is provided for backwards compatibility with older versions of .NET.
+    /// </remarks>
     public abstract class MSBuildTestBase
     {
         static MSBuildTestBase()
         {
-            Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", MSBuildAssemblyResolver.MSBuildExePath);
-            Environment.SetEnvironmentVariable("MSBuildExtensionsPath", MSBuildAssemblyResolver.DotNetSdksPath);
-            Environment.SetEnvironmentVariable("MSBuildSDKsPath", string.IsNullOrWhiteSpace(MSBuildAssemblyResolver.DotNetSdksPath) ? null : Path.Combine(MSBuildAssemblyResolver.DotNetSdksPath, "Sdks"));
-
-#if NET6_0_OR_GREATER
-            AssemblyLoadContext.Default.Resolving += MSBuildAssemblyResolver.AssemblyResolve;
-#else
-            AppDomain.CurrentDomain.AssemblyResolve += MSBuildAssemblyResolver.AssemblyResolve;
-#endif
+            MSBuildAssemblyResolver.Register();
         }
     }
 }

--- a/src/Microsoft.Build.Utilities.ProjectCreation/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -293,6 +293,7 @@ static Microsoft.Build.Utilities.ProjectCreation.ExtensionMethods.ToArrayWithSin
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.AssemblyResolve(object? sender, System.ResolveEventArgs! args) -> System.Reflection.Assembly?
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.DotNetSdksPath.get -> string?
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.MSBuildExePath.get -> string?
+static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.Register() -> void
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.SearchPaths.get -> string![]?
 static Microsoft.Build.Utilities.ProjectCreation.PackageFeed.Create(string! rootPath) -> Microsoft.Build.Utilities.ProjectCreation.PackageFeed!
 static Microsoft.Build.Utilities.ProjectCreation.PackageFeed.Create(System.IO.DirectoryInfo! rootPath) -> Microsoft.Build.Utilities.ProjectCreation.PackageFeed!

--- a/src/Microsoft.Build.Utilities.ProjectCreation/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -293,6 +293,7 @@ static Microsoft.Build.Utilities.ProjectCreation.ExtensionMethods.ToArrayWithSin
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.AssemblyResolve(System.Runtime.Loader.AssemblyLoadContext! assemblyLoadContext, System.Reflection.AssemblyName! requestedAssemblyName) -> System.Reflection.Assembly?
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.DotNetSdksPath.get -> string?
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.MSBuildExePath.get -> string?
+static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.Register() -> void
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.SearchPaths.get -> string![]?
 static Microsoft.Build.Utilities.ProjectCreation.PackageFeed.Create(string! rootPath) -> Microsoft.Build.Utilities.ProjectCreation.PackageFeed!
 static Microsoft.Build.Utilities.ProjectCreation.PackageFeed.Create(System.IO.DirectoryInfo! rootPath) -> Microsoft.Build.Utilities.ProjectCreation.PackageFeed!

--- a/src/Microsoft.Build.Utilities.ProjectCreation/PublicAPI/net7.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/PublicAPI/net7.0/PublicAPI.Shipped.txt
@@ -293,6 +293,7 @@ static Microsoft.Build.Utilities.ProjectCreation.ExtensionMethods.ToArrayWithSin
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.AssemblyResolve(System.Runtime.Loader.AssemblyLoadContext! assemblyLoadContext, System.Reflection.AssemblyName! requestedAssemblyName) -> System.Reflection.Assembly?
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.DotNetSdksPath.get -> string?
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.MSBuildExePath.get -> string?
+static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.Register() -> void
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.SearchPaths.get -> string![]?
 static Microsoft.Build.Utilities.ProjectCreation.PackageFeed.Create(string! rootPath) -> Microsoft.Build.Utilities.ProjectCreation.PackageFeed!
 static Microsoft.Build.Utilities.ProjectCreation.PackageFeed.Create(System.IO.DirectoryInfo! rootPath) -> Microsoft.Build.Utilities.ProjectCreation.PackageFeed!

--- a/src/Microsoft.Build.Utilities.ProjectCreation/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -293,6 +293,7 @@ static Microsoft.Build.Utilities.ProjectCreation.ExtensionMethods.ToArrayWithSin
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.AssemblyResolve(System.Runtime.Loader.AssemblyLoadContext! assemblyLoadContext, System.Reflection.AssemblyName! requestedAssemblyName) -> System.Reflection.Assembly?
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.DotNetSdksPath.get -> string?
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.MSBuildExePath.get -> string?
+static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.Register() -> void
 static Microsoft.Build.Utilities.ProjectCreation.MSBuildAssemblyResolver.SearchPaths.get -> string![]?
 static Microsoft.Build.Utilities.ProjectCreation.PackageFeed.Create(string! rootPath) -> Microsoft.Build.Utilities.ProjectCreation.PackageFeed!
 static Microsoft.Build.Utilities.ProjectCreation.PackageFeed.Create(System.IO.DirectoryInfo! rootPath) -> Microsoft.Build.Utilities.ProjectCreation.PackageFeed!


### PR DESCRIPTION
The MSBuild location / initialization code was only available in the `MSBuildTestBase` abstract class for unit tests.

Using a base class for this purpose can create multiple inheritance problems when combined with other testing tools. To allow more flexibility in how the assembly resolution is done, I moved the code to `MSBuildAssemblyResolver.Register()`, and forward the call from `MSBuildTestBase` for backwards compatibility.

I wrapped registration in a `Lazy` to prevent registration from happening multiple times. However, I don't think that's _technically_ necessary, so I can remove that if desired.

I also updated the README section on resolving MSBuild. I'm not an SDK resolution expert, but I believe the old option 2 was insufficient, so I removed it and added a new "preferred" method of using a Module initializer if possible (which is also morally equivalent).