### PR TITLE
Support any namespace in NuspecReader

### DIFF
--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/NuspecReaderTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/NuspecReaderTests.cs
@@ -34,5 +34,29 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
             nuspec.LicenseVersion.ShouldBeNull();
             nuspec.LicenseUrl.ShouldBeNull();
         }
+
+        // List of namespaces from https://github.com/NuGet/NuGet.Client/blob/6917e6c883d45f45672e20d4b1c45758dad2fa84/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs#L23-L50
+        [Theory]
+        [InlineData("http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd")]
+        [InlineData("http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd")]
+        [InlineData("http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd")]
+        [InlineData("http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd")]
+        [InlineData("http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd")]
+        [InlineData("http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd")]
+        public void ReaderCanParseKnownXmlNamespaces(string xmlns)
+        {
+            string contents =
+$@"<package xmlns=""{xmlns}"">
+  <metadata>
+    <id>PackageL</id>
+    <version>16.4.60</version>
+  </metadata>
+</package>";
+
+            NuspecReader nuspec = new NuspecReader(contents);
+
+            nuspec.Id.ShouldBe("PackageL");
+            nuspec.Version.ShouldBe("16.4.60");
+        }
     }
 }


### PR DESCRIPTION
The NuspecReader was hardcoded to always assume the nuspec v6 schema. However, the NuGet client will use the _oldest_ schema it can when creating a package.

Update the reader so it uses whatever the provided XML schema is.