### PR TITLE
Enable transitive pins and bump System.Text.Json

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,8 +2,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <MicrosoftBuildPackageVersion>17.11.4</MicrosoftBuildPackageVersion>
     <MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'net6.0'">17.3.2</MicrosoftBuildPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup Label="Transitive pins">
+    <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>
+    <SystemTextJsonVersion Condition="'$(TargetFramework)' == 'net6.0'">6.0.10</SystemTextJsonVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AssemblyShader" Version="1.0.3-preview" />
@@ -16,7 +21,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.11.2177" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/src/Microsoft.Build.Utilities.ProjectCreation/Microsoft.Build.Utilities.ProjectCreation.csproj
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/Microsoft.Build.Utilities.ProjectCreation.csproj
@@ -32,7 +32,6 @@
     <PackageReference Include="Microsoft.IO.Redist" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Condition="'$(TargetFramework)' == 'net472'" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net472'" />
-    <PackageReference Include="System.Text.Json" Condition="'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'" />
     <PackageReference Include="System.ValueTuple" VersionOverride="4.5.0" Condition="'$(TargetFramework)' == 'net472'" ExcludeAssets="Compile" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fix broken build due to NU1903.

To do so I:

1. Enabled transitive pinning
2. Bumped System.Text.Json to 6.0.10 for .NET 6.0
3. Bumped System.Text.Json to 8.0.5 for all other TFMs

This mirrors the existing logic, but it isn't entirely clear to me why it was this way to begin with.

Comparing packages before and after, the version is bumped as expected (and no other package dependencies change) _except_ the .NET 6.0 TFM now has a dependency on System.Text.Json.