### PR TITLE
Drop support for .NET 6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,6 @@ env:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'Any CPU'
   ContinuousIntegrationBuild: 'true'
-  DotNet6Version: '6.x'
   DotNet8Version: '8.x'
   DotNet9Version: '9.x'
 
@@ -43,11 +42,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET ${{ env.DotNet6Version }} and .NET ${{ env.DotNet8Version }}
+    - name: Install .NET ${{ env.DotNet8Version }}
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          ${{ env.DotNet6Version }}
           ${{ env.DotNet8Version }}
 
     - name: Install .NET ${{ env.DotNet9Version }}
@@ -62,10 +60,6 @@ jobs:
     - name: Run Unit Tests (.NET Framework)
       if: ${{ matrix.name == 'Windows' }}
       run: dotnet test --no-restore --no-build --framework net472 "/Property:Platform=${{ env.BuildPlatform }};Configuration=${{ env.BuildConfiguration }}" "/BinaryLogger:${{ env.ArtifactsDirectoryName }}/test-net472.binlog"
-
-    - name: Run Unit Tests (.NET 6)
-      if: ${{ matrix.name != 'MacOS' }}
-      run: dotnet test --no-restore --no-build --framework net6.0 "/Property:Platform=${{ env.BuildPlatform }};Configuration=${{ env.BuildConfiguration }}" "/BinaryLogger:${{ env.ArtifactsDirectoryName }}/test-net6.0.binlog"
 
     - name: Run Unit Tests (.NET 8)
       run: dotnet test --no-restore --no-build --framework net8.0 "/Property:Platform=${{ env.BuildPlatform }};Configuration=${{ env.BuildConfiguration }}" "/BinaryLogger:${{ env.ArtifactsDirectoryName }}/test-net8.0.binlog"

--- a/.github/workflows/Official.yml
+++ b/.github/workflows/Official.yml
@@ -15,7 +15,6 @@ env:
   BuildPlatform: 'Any CPU'
   ContinuousIntegrationBuild: 'true'
   OfficialBuild: 'true'
-  DotNet6Version: '6.x'
   DotNet8Version: '8.x'
 
 jobs:
@@ -29,11 +28,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET ${{ env.DotNet6Version }} and .NET ${{ env.DotNet8Version }}
+    - name: Install .NET ${{ env.DotNet8Version }}
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          ${{ env.DotNet6Version }}
           ${{ env.DotNet8Version }}
 
     - name: Install .NET ${{ env.DotNet9Version }}

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/BuildTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/BuildTests.cs
@@ -144,13 +144,11 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
             {
                 projects.Add(
                     ProjectCreator.Create(GetTempProjectPath())
+                        .UsingTaskRoslynCodeTaskFactory(
+                            taskName: "Sleep",
+                            sourceCode: "System.Threading.Thread.Sleep(2000);")
                         .Target("Build")
-                        .Task(
-                            "Exec",
-                            parameters: new Dictionary<string, string?>
-                            {
-                                ["Command"] = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ping 127.0.0.1 -n 2 >NUL" : "sleep 2",
-                            })
+                        .Task("Sleep")
                         .Save());
             }
 

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/Microsoft.Build.Utilities.ProjectCreation.UnitTests.csproj
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/Microsoft.Build.Utilities.ProjectCreation.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <Import Project="..\Microsoft.Build.Utilities.ProjectCreation\build\MSBuild.ProjectCreation.props" Condition="'$(TargetFramework)' == 'net472'" />

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/SdkCsprojTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/SdkCsprojTests.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
 {
     public class SdkCsprojTests : TestBase
     {
-#if !NET6_0
         [Fact]
         public void CanBuild()
         {
@@ -21,7 +20,6 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
 
             result.ShouldBeTrue(buildOutput.GetConsoleLog());
         }
-#endif
 
         [Fact]
         public void CustomSdk()

--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/TestBase.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/TestBase.cs
@@ -18,9 +18,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
         public string DotNetSdkVersion
         {
             get =>
-#if NET6_0
-            "6.0.100";
-#elif  NET8_0 || NETFRAMEWORK
+#if  NET8_0 || NETFRAMEWORK
             "8.0.100";
 #elif  NET9_0 || NETFRAMEWORK
             "9.0.0";
@@ -32,9 +30,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
         public string TargetFramework
         {
             get =>
-#if NET6_0
-            "net6.0";
-#elif NET8_0
+#if NET8_0
             "net8.0";
 #elif NET9_0
             "net9.0";

--- a/src/Microsoft.Build.Utilities.ProjectCreation/MSBuildAssemblyResolver.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/MSBuildAssemblyResolver.cs
@@ -7,7 +7,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 
@@ -28,10 +28,11 @@ namespace Microsoft.Build.Utilities.ProjectCreation
             Environment.SetEnvironmentVariable("MSBuildExtensionsPath", DotNetSdksPath);
             Environment.SetEnvironmentVariable("MSBuildSDKsPath", string.IsNullOrWhiteSpace(DotNetSdksPath) ? null : Path.Combine(DotNetSdksPath, "Sdks"));
 
-#if NET6_0_OR_GREATER
-            AssemblyLoadContext.Default.Resolving += AssemblyResolve;
-#else
+#if NETFRAMEWORK
             AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve;
+
+#else
+            AssemblyLoadContext.Default.Resolving += AssemblyResolve;
 #endif
 
             return new object();
@@ -78,7 +79,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
                             }
 
                             AssemblyName candidateAssemblyName = AssemblyName.GetAssemblyName(candidateAssemblyFile.FullName);
-#if !NET7_0_OR_GREATER
+#if NETFRAMEWORK
                             if (requestedAssemblyName.ProcessorArchitecture != System.Reflection.ProcessorArchitecture.None && requestedAssemblyName.ProcessorArchitecture != candidateAssemblyName.ProcessorArchitecture)
                             {
                                 // The requested assembly has a processor architecture and the candidate assembly has a different value

--- a/src/Microsoft.Build.Utilities.ProjectCreation/Microsoft.Build.Utilities.ProjectCreation.csproj
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/Microsoft.Build.Utilities.ProjectCreation.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <ArtifactsPath>..\..\artifacts\$(MSBuildProjectName)</ArtifactsPath>
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" Condition="'$(OfficialBuild)' != 'true'" />
     <PackageReference Include="Microsoft.IO.Redist" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Condition="'$(TargetFramework)' == 'net472'" ExcludeAssets="Runtime" PrivateAssets="All" />
+    <PackageReference Include="System.CodeDom" VersionOverride="9.0.0-rc.2.24473.5" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageReference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.ValueTuple" VersionOverride="4.5.0" Condition="'$(TargetFramework)' == 'net472'" ExcludeAssets="Compile" />

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "13.0",
+  "version": "14.0",
   "assemblyVersion": "1.0",
   "buildNumberOffset": -2,
   "nugetPackageVersion": {


### PR DESCRIPTION
Also use RoslynCodeTaskFactory in build tests and pin System.CodeDom for .NET 9.