### PR TITLE
Fix for not calling restore during build for certain overload

### DIFF
--- a/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/BuildTests.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation.UnitTests/BuildTests.cs
@@ -277,6 +277,52 @@ namespace Microsoft.Build.Utilities.ProjectCreation.UnitTests
         }
 
         [Fact]
+        public void TryBuildWithRestoreAndTargetWithoutBuildOutputRestoresBeforeBuild()
+        {
+            string markerPath = Path.Combine(TestRootPath, $"{Guid.NewGuid():N}.restore-marker");
+
+            ProjectCreator.Create(path: GetTempFileName(".proj"))
+                .Target("Restore")
+                    .Task(
+                        "WriteLinesToFile",
+                        parameters: new Dictionary<string, string?>
+                        {
+                            ["File"] = markerPath,
+                            ["Lines"] = "restored",
+                            ["Overwrite"] = bool.TrueString,
+                        })
+                .Target("Build")
+                    .TaskError("Restore target did not run.", condition: $"!Exists('{markerPath}')")
+                .Save()
+                .TryBuild(restore: true, target: "Build", globalProperties: null, out bool result);
+
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void TryBuildWithRestoreWithoutBuildOutputRestoresBeforeBuild()
+        {
+            string markerPath = Path.Combine(TestRootPath, $"{Guid.NewGuid():N}.restore-marker");
+
+            ProjectCreator.Create(path: GetTempFileName(".proj"), defaultTargets: "Build")
+                .Target("Restore")
+                    .Task(
+                        "WriteLinesToFile",
+                        parameters: new Dictionary<string, string?>
+                        {
+                            ["File"] = markerPath,
+                            ["Lines"] = "restored",
+                            ["Overwrite"] = bool.TrueString,
+                        })
+                .Target("Build")
+                    .TaskError("Restore target did not run.", condition: $"!Exists('{markerPath}')")
+                .Save()
+                .TryBuild(restore: true, globalProperties: null, out bool result);
+
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
         public void ProjectCollectionLoggersWork()
         {
             string binLogPath = Path.Combine(TestRootPath, "test.binlog");

--- a/src/Microsoft.Build.Utilities.ProjectCreation/ProjectCreator.Build.cs
+++ b/src/Microsoft.Build.Utilities.ProjectCreation/ProjectCreator.Build.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         {
             BuildOutput buildOutput = BuildOutput.Create();
 
-            result = Build(restore: false, [target], globalProperties, buildOutput, out _);
+            result = Build(restore, [target], globalProperties, buildOutput, out _);
 
             return this;
         }
@@ -163,7 +163,7 @@ namespace Microsoft.Build.Utilities.ProjectCreation
         {
             BuildOutput buildOutput = BuildOutput.Create();
 
-            result = Build(restore: false, targets: null, globalProperties, buildOutput, out _);
+            result = Build(restore, targets: null, globalProperties, buildOutput, out _);
 
             return this;
         }


### PR DESCRIPTION
Reported by @BenjaminBrienen-CanonPP at https://github.com/jeffkl/MSBuildProjectCreator/pull/356/changes#r3470997421, broken in https://github.com/jeffkl/MSBuildProjectCreator/pull/356

Overloads for `TryBuild()` incorrectly pass a constant value for `restore` rather than use the input parameter.